### PR TITLE
Widen beatmap volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV ASPNETCORE_ENVIRONMENT=Production
 ENV BEATMAP_DIRECTORY=/beatmaps
 
 VOLUME ${BEATMAP_DIRECTORY}
-RUN mkdir ${BEATMAP_DIRECTORY} && chown -R app:app ${BEATMAP_DIRECTORY}
+# chmod 777 so that this volume can be read/written by other containers that might use different uids
+RUN mkdir ${BEATMAP_DIRECTORY} && chmod -R 777 ${BEATMAP_DIRECTORY}
 
 USER app
 


### PR DESCRIPTION
## Why?

If difficalcy is the first container to be used with the mount, it's permissions will be persisted for the volume.
If then osuchan or another service starts using the same volume, it will be subject to difficalcy's permissions, which can't be guaranteed without a 777 or strictly same UIDs.

## Changes

- Widen `/beatmaps` volume to `777` permissions