### PR TITLE
Only run deploy-docs workflow on master

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,5 +1,9 @@
 name: deploy-docs
-on: [push]
+on:
+  push:
+    branches:
+      - master
+
 jobs:
   build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Why?

Oops... we don't want every branch build to fail.