### PR TITLE
Use .osu extension for beatmaps

### DIFF
--- a/Difficalcy.Catch/Controllers/CatchCalculatorController.cs
+++ b/Difficalcy.Catch/Controllers/CatchCalculatorController.cs
@@ -4,8 +4,7 @@ using Difficalcy.Catch.Services;
 
 namespace Difficalcy.Catch.Controllers
 {
-    public class CatchCalculatorController : CalculatorController<CatchScore, CatchDifficulty, CatchPerformance, CatchCalculation, CatchCalculatorService>
+    public class CatchCalculatorController(CatchCalculatorService calculatorService) : CalculatorController<CatchScore, CatchDifficulty, CatchPerformance, CatchCalculation, CatchCalculatorService>(calculatorService)
     {
-        public CatchCalculatorController(CatchCalculatorService calculatorService) : base(calculatorService) { }
     }
 }

--- a/Difficalcy.Catch/Services/CalculatorWorkingBeatmap.cs
+++ b/Difficalcy.Catch/Services/CalculatorWorkingBeatmap.cs
@@ -14,7 +14,7 @@ namespace Difficalcy.Catch.Services
     {
         private readonly Beatmap _beatmap;
 
-        public CalculatorWorkingBeatmap(Ruleset ruleset, Stream beatmapStream, string beatmapId) : this(ruleset, readFromStream(beatmapStream), beatmapId) { }
+        public CalculatorWorkingBeatmap(Ruleset ruleset, Stream beatmapStream, string beatmapId) : this(ruleset, ReadFromStream(beatmapStream), beatmapId) { }
 
         private CalculatorWorkingBeatmap(Ruleset ruleset, Beatmap beatmap, string beatmapId) : base(beatmap.BeatmapInfo, null)
         {
@@ -24,7 +24,7 @@ namespace Difficalcy.Catch.Services
             _beatmap.BeatmapInfo.Ruleset = beatmap.BeatmapInfo.Ruleset.OnlineID == 0 ? (new OsuRuleset()).RulesetInfo : ruleset.RulesetInfo;
         }
 
-        private static Beatmap readFromStream(Stream stream)
+        private static Beatmap ReadFromStream(Stream stream)
         {
             using var reader = new LineBufferedReader(stream);
             return Decoder.GetDecoder<Beatmap>(reader).Decode(reader);

--- a/Difficalcy.Catch/Startup.cs
+++ b/Difficalcy.Catch/Startup.cs
@@ -5,10 +5,8 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Difficalcy.Catch
 {
-    public class Startup : DifficalcyStartup
+    public class Startup(IConfiguration configuration) : DifficalcyStartup(configuration)
     {
-        public Startup(IConfiguration configuration) : base(configuration) { }
-
         public override string OpenApiTitle => "Difficalcy.Catch";
 
         public override string OpenApiVersion => "v1";

--- a/Difficalcy.Mania/Controllers/ManiaCalculatorController.cs
+++ b/Difficalcy.Mania/Controllers/ManiaCalculatorController.cs
@@ -4,8 +4,7 @@ using Difficalcy.Mania.Services;
 
 namespace Difficalcy.Mania.Controllers
 {
-    public class ManiaCalculatorController : CalculatorController<ManiaScore, ManiaDifficulty, ManiaPerformance, ManiaCalculation, ManiaCalculatorService>
+    public class ManiaCalculatorController(ManiaCalculatorService calculatorService) : CalculatorController<ManiaScore, ManiaDifficulty, ManiaPerformance, ManiaCalculation, ManiaCalculatorService>(calculatorService)
     {
-        public ManiaCalculatorController(ManiaCalculatorService calculatorService) : base(calculatorService) { }
     }
 }

--- a/Difficalcy.Mania/Services/CalculatorWorkingBeatmap.cs
+++ b/Difficalcy.Mania/Services/CalculatorWorkingBeatmap.cs
@@ -14,7 +14,7 @@ namespace Difficalcy.Mania.Services
     {
         private readonly Beatmap _beatmap;
 
-        public CalculatorWorkingBeatmap(Ruleset ruleset, Stream beatmapStream, string beatmapId) : this(ruleset, readFromStream(beatmapStream), beatmapId) { }
+        public CalculatorWorkingBeatmap(Ruleset ruleset, Stream beatmapStream, string beatmapId) : this(ruleset, ReadFromStream(beatmapStream), beatmapId) { }
 
         private CalculatorWorkingBeatmap(Ruleset ruleset, Beatmap beatmap, string beatmapId) : base(beatmap.BeatmapInfo, null)
         {
@@ -24,7 +24,7 @@ namespace Difficalcy.Mania.Services
             _beatmap.BeatmapInfo.Ruleset = beatmap.BeatmapInfo.Ruleset.OnlineID == 0 ? (new OsuRuleset()).RulesetInfo : ruleset.RulesetInfo;
         }
 
-        private static Beatmap readFromStream(Stream stream)
+        private static Beatmap ReadFromStream(Stream stream)
         {
             using var reader = new LineBufferedReader(stream);
             return Decoder.GetDecoder<Beatmap>(reader).Decode(reader);

--- a/Difficalcy.Mania/Services/ManiaCalculatorService.cs
+++ b/Difficalcy.Mania/Services/ManiaCalculatorService.cs
@@ -16,9 +16,9 @@ using osu.Game.Scoring;
 
 namespace Difficalcy.Mania.Services
 {
-    public class ManiaCalculatorService : CalculatorService<ManiaScore, ManiaDifficulty, ManiaPerformance, ManiaCalculation>
+    public class ManiaCalculatorService(ICache cache, IBeatmapProvider beatmapProvider) : CalculatorService<ManiaScore, ManiaDifficulty, ManiaPerformance, ManiaCalculation>(cache)
     {
-        private readonly IBeatmapProvider _beatmapProvider;
+        private readonly IBeatmapProvider _beatmapProvider = beatmapProvider;
         private ManiaRuleset ManiaRuleset { get; } = new ManiaRuleset();
 
         public override CalculatorInfo Info
@@ -36,11 +36,6 @@ namespace Difficalcy.Mania.Services
                     CalculatorUrl = $"https://nuget.org/packages/ppy.{packageName}/{packageVersion}"
                 };
             }
-        }
-
-        public ManiaCalculatorService(ICache cache, IBeatmapProvider beatmapProvider) : base(cache)
-        {
-            _beatmapProvider = beatmapProvider;
         }
 
         protected override async Task EnsureBeatmap(string beatmapId)

--- a/Difficalcy.Mania/Startup.cs
+++ b/Difficalcy.Mania/Startup.cs
@@ -5,10 +5,8 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Difficalcy.Mania
 {
-    public class Startup : DifficalcyStartup
+    public class Startup(IConfiguration configuration) : DifficalcyStartup(configuration)
     {
-        public Startup(IConfiguration configuration) : base(configuration) { }
-
         public override string OpenApiTitle => "Difficalcy.Mania";
 
         public override string OpenApiVersion => "v1";

--- a/Difficalcy.Osu/Controllers/OsuCalculatorController.cs
+++ b/Difficalcy.Osu/Controllers/OsuCalculatorController.cs
@@ -4,8 +4,7 @@ using Difficalcy.Osu.Services;
 
 namespace Difficalcy.Osu.Controllers
 {
-    public class OsuCalculatorController : CalculatorController<OsuScore, OsuDifficulty, OsuPerformance, OsuCalculation, OsuCalculatorService>
+    public class OsuCalculatorController(OsuCalculatorService calculatorService) : CalculatorController<OsuScore, OsuDifficulty, OsuPerformance, OsuCalculation, OsuCalculatorService>(calculatorService)
     {
-        public OsuCalculatorController(OsuCalculatorService calculatorService) : base(calculatorService) { }
     }
 }

--- a/Difficalcy.Osu/Services/CalculatorWorkingBeatmap.cs
+++ b/Difficalcy.Osu/Services/CalculatorWorkingBeatmap.cs
@@ -13,7 +13,7 @@ namespace Difficalcy.Osu.Services
     {
         private readonly Beatmap _beatmap;
 
-        public CalculatorWorkingBeatmap(Ruleset ruleset, Stream beatmapStream, string beatmapId) : this(ruleset, readFromStream(beatmapStream), beatmapId) { }
+        public CalculatorWorkingBeatmap(Ruleset ruleset, Stream beatmapStream, string beatmapId) : this(ruleset, ReadFromStream(beatmapStream), beatmapId) { }
 
         private CalculatorWorkingBeatmap(Ruleset ruleset, Beatmap beatmap, string beatmapId) : base(beatmap.BeatmapInfo, null)
         {
@@ -22,7 +22,7 @@ namespace Difficalcy.Osu.Services
             _beatmap.BeatmapInfo.Ruleset = ruleset.RulesetInfo;
         }
 
-        private static Beatmap readFromStream(Stream stream)
+        private static Beatmap ReadFromStream(Stream stream)
         {
             using var reader = new LineBufferedReader(stream);
             return Decoder.GetDecoder<Beatmap>(reader).Decode(reader);

--- a/Difficalcy.Osu/Startup.cs
+++ b/Difficalcy.Osu/Startup.cs
@@ -5,10 +5,8 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Difficalcy.Osu
 {
-    public class Startup : DifficalcyStartup
+    public class Startup(IConfiguration configuration) : DifficalcyStartup(configuration)
     {
-        public Startup(IConfiguration configuration) : base(configuration) { }
-
         public override string OpenApiTitle => "Difficalcy.Osu";
 
         public override string OpenApiVersion => "v1";

--- a/Difficalcy.Taiko/Controllers/TaikoCalculatorController.cs
+++ b/Difficalcy.Taiko/Controllers/TaikoCalculatorController.cs
@@ -4,8 +4,7 @@ using Difficalcy.Taiko.Services;
 
 namespace Difficalcy.Taiko.Controllers
 {
-    public class TaikoCalculatorController : CalculatorController<TaikoScore, TaikoDifficulty, TaikoPerformance, TaikoCalculation, TaikoCalculatorService>
+    public class TaikoCalculatorController(TaikoCalculatorService calculatorService) : CalculatorController<TaikoScore, TaikoDifficulty, TaikoPerformance, TaikoCalculation, TaikoCalculatorService>(calculatorService)
     {
-        public TaikoCalculatorController(TaikoCalculatorService calculatorService) : base(calculatorService) { }
     }
 }

--- a/Difficalcy.Taiko/Services/CalculatorWorkingBeatmap.cs
+++ b/Difficalcy.Taiko/Services/CalculatorWorkingBeatmap.cs
@@ -14,7 +14,7 @@ namespace Difficalcy.Taiko.Services
     {
         private readonly Beatmap _beatmap;
 
-        public CalculatorWorkingBeatmap(Ruleset ruleset, Stream beatmapStream, string beatmapId) : this(ruleset, readFromStream(beatmapStream), beatmapId) { }
+        public CalculatorWorkingBeatmap(Ruleset ruleset, Stream beatmapStream, string beatmapId) : this(ruleset, ReadFromStream(beatmapStream), beatmapId) { }
 
         private CalculatorWorkingBeatmap(Ruleset ruleset, Beatmap beatmap, string beatmapId) : base(beatmap.BeatmapInfo, null)
         {
@@ -24,7 +24,7 @@ namespace Difficalcy.Taiko.Services
             _beatmap.BeatmapInfo.Ruleset = beatmap.BeatmapInfo.Ruleset.OnlineID == 0 ? (new OsuRuleset()).RulesetInfo : ruleset.RulesetInfo;
         }
 
-        private static Beatmap readFromStream(Stream stream)
+        private static Beatmap ReadFromStream(Stream stream)
         {
             using var reader = new LineBufferedReader(stream);
             return Decoder.GetDecoder<Beatmap>(reader).Decode(reader);

--- a/Difficalcy.Taiko/Services/TaikoCalculatorService.cs
+++ b/Difficalcy.Taiko/Services/TaikoCalculatorService.cs
@@ -16,9 +16,9 @@ using osu.Game.Scoring;
 
 namespace Difficalcy.Taiko.Services
 {
-    public class TaikoCalculatorService : CalculatorService<TaikoScore, TaikoDifficulty, TaikoPerformance, TaikoCalculation>
+    public class TaikoCalculatorService(ICache cache, IBeatmapProvider beatmapProvider) : CalculatorService<TaikoScore, TaikoDifficulty, TaikoPerformance, TaikoCalculation>(cache)
     {
-        private readonly IBeatmapProvider _beatmapProvider;
+        private readonly IBeatmapProvider _beatmapProvider = beatmapProvider;
         private TaikoRuleset TaikoRuleset { get; } = new TaikoRuleset();
 
         public override CalculatorInfo Info
@@ -36,11 +36,6 @@ namespace Difficalcy.Taiko.Services
                     CalculatorUrl = $"https://nuget.org/packages/ppy.{packageName}/{packageVersion}"
                 };
             }
-        }
-
-        public TaikoCalculatorService(ICache cache, IBeatmapProvider beatmapProvider) : base(cache)
-        {
-            _beatmapProvider = beatmapProvider;
         }
 
         protected override async Task EnsureBeatmap(string beatmapId)

--- a/Difficalcy.Taiko/Startup.cs
+++ b/Difficalcy.Taiko/Startup.cs
@@ -5,10 +5,8 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Difficalcy.Taiko
 {
-    public class Startup : DifficalcyStartup
+    public class Startup(IConfiguration configuration) : DifficalcyStartup(configuration)
     {
-        public Startup(IConfiguration configuration) : base(configuration) { }
-
         public override string OpenApiTitle => "Difficalcy.Taiko";
 
         public override string OpenApiVersion => "v1";

--- a/Difficalcy.Tests/DummyCalculatorServiceTest.cs
+++ b/Difficalcy.Tests/DummyCalculatorServiceTest.cs
@@ -11,20 +11,16 @@ public class DummyCalculatorServiceTest : CalculatorServiceTest<DummyScore, Dumm
     [InlineData(15, 1500, "test 1", 150)]
     [InlineData(10, 1000, "test 2", 100)]
     public void Test(double expectedDifficultyTotal, double expectedPerformanceTotal, string beatmapId, int mods)
-        => base.TestGetCalculationReturnsCorrectValues(expectedDifficultyTotal, expectedPerformanceTotal, new DummyScore { BeatmapId = beatmapId, Mods = mods });
+        => TestGetCalculationReturnsCorrectValues(expectedDifficultyTotal, expectedPerformanceTotal, new DummyScore { BeatmapId = beatmapId, Mods = mods });
 }
 
 /// <summary>
 /// A dummy calculator service implementation that calculates difficulty as (beatmap id + mods) / 10 and performance as difficulty * 100
 /// </summary>
-public class DummyCalculatorService : CalculatorService<DummyScore, DummyDifficulty, DummyPerformance, DummyCalculation>
+public class DummyCalculatorService(ICache cache) : CalculatorService<DummyScore, DummyDifficulty, DummyPerformance, DummyCalculation>(cache)
 {
-    public DummyCalculatorService(ICache cache) : base(cache)
-    {
-    }
-
     public override CalculatorInfo Info =>
-        new CalculatorInfo
+        new()
         {
             RulesetName = "Dummy",
             CalculatorName = "Dummy calculator",
@@ -40,7 +36,7 @@ public class DummyCalculatorService : CalculatorService<DummyScore, DummyDifficu
     }
 
     protected override DummyCalculation CalculatePerformance(DummyScore score, object difficultyAttributes) =>
-        new DummyCalculation()
+        new()
         {
             Difficulty = new DummyDifficulty() { Total = (double)difficultyAttributes },
             Performance = new DummyPerformance() { Total = (double)difficultyAttributes * 100 }

--- a/Difficalcy/Controllers/CalculatorController.cs
+++ b/Difficalcy/Controllers/CalculatorController.cs
@@ -9,19 +9,14 @@ namespace Difficalcy.Controllers
     [ApiController]
     [Route("/api")]
     [Produces("application/json")]
-    public abstract class CalculatorController<TScore, TDifficulty, TPerformance, TCalculation, TCalculatorService> : ControllerBase
+    public abstract class CalculatorController<TScore, TDifficulty, TPerformance, TCalculation, TCalculatorService>(TCalculatorService calculatorService) : ControllerBase
         where TScore : Score
         where TDifficulty : Difficulty
         where TPerformance : Performance
         where TCalculation : Calculation<TDifficulty, TPerformance>
         where TCalculatorService : CalculatorService<TScore, TDifficulty, TPerformance, TCalculation>
     {
-        protected readonly TCalculatorService calculatorService;
-
-        public CalculatorController(TCalculatorService calculatorService)
-        {
-            this.calculatorService = calculatorService;
-        }
+        protected readonly TCalculatorService calculatorService = calculatorService;
 
         /// <summary>
         /// Returns a set of information describing the calculator.

--- a/Difficalcy/DifficalcyStartup.cs
+++ b/Difficalcy/DifficalcyStartup.cs
@@ -9,7 +9,7 @@ using StackExchange.Redis;
 
 namespace Difficalcy
 {
-    abstract public class DifficalcyStartup
+    abstract public class DifficalcyStartup(IConfiguration configuration)
     {
         public abstract string OpenApiTitle { get; }
 
@@ -20,12 +20,7 @@ namespace Difficalcy
         /// </summary>
         protected abstract string TestBeatmapAssembly { get; }
 
-        public DifficalcyStartup(IConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
-
-        public IConfiguration Configuration { get; }
+        public IConfiguration Configuration { get; } = configuration;
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)

--- a/Difficalcy/Services/InMemoryCache.cs
+++ b/Difficalcy/Services/InMemoryCache.cs
@@ -14,7 +14,7 @@ namespace Difficalcy.Services
 
     public class InMemoryCache : ICache
     {
-        private InMemoryCacheDatabase _database = new InMemoryCacheDatabase();
+        private readonly InMemoryCacheDatabase _database = new();
 
         public ICacheDatabase GetDatabase() => _database;
     }

--- a/Difficalcy/Services/RedisCache.cs
+++ b/Difficalcy/Services/RedisCache.cs
@@ -3,18 +3,11 @@ using StackExchange.Redis;
 
 namespace Difficalcy.Services
 {
-    public class RedisCacheDatabase : ICacheDatabase
+    public class RedisCacheDatabase(IDatabase redisDatabase) : ICacheDatabase
     {
-        private IDatabase _redisDatabase;
-
-        public RedisCacheDatabase(IDatabase redisDatabase)
-        {
-            _redisDatabase = redisDatabase;
-        }
-
         public async Task<string> GetAsync(string key)
         {
-            var redisValue = await _redisDatabase.StringGetAsync(key);
+            var redisValue = await redisDatabase.StringGetAsync(key);
 
             if (redisValue.IsNull)
                 return null;
@@ -24,18 +17,13 @@ namespace Difficalcy.Services
 
         public void Set(string key, string value)
         {
-            _redisDatabase.StringSet(key, value, flags: CommandFlags.FireAndForget);
+            redisDatabase.StringSet(key, value, flags: CommandFlags.FireAndForget);
         }
     }
 
-    public class RedisCache : ICache
+    public class RedisCache(IConnectionMultiplexer redis) : ICache
     {
-        private IConnectionMultiplexer _redis;
-
-        public RedisCache(IConnectionMultiplexer redis)
-        {
-            _redis = redis;
-        }
+        private readonly IConnectionMultiplexer _redis = redis;
 
         public ICacheDatabase GetDatabase()
         {

--- a/Difficalcy/Services/TestBeatmapProvider.cs
+++ b/Difficalcy/Services/TestBeatmapProvider.cs
@@ -5,18 +5,11 @@ using System.Threading.Tasks;
 
 namespace Difficalcy.Services
 {
-    public class TestBeatmapProvider : IBeatmapProvider
+    public class TestBeatmapProvider(string resourceAssemblyName) : IBeatmapProvider
     {
-        private string _resourceAssemblyName;
-
-        public TestBeatmapProvider(string resourceAssemblyName)
-        {
-            _resourceAssemblyName = resourceAssemblyName;
-        }
-
         public Task<bool> EnsureBeatmap(string beatmapId)
         {
-            var resourceName = $"{_resourceAssemblyName}.Resources.{beatmapId}";
+            var resourceName = $"{resourceAssemblyName}.Resources.{beatmapId}";
             var info = ResourceAssembly.GetManifestResourceInfo(resourceName);
             return Task.FromResult(info != null);
         }
@@ -25,10 +18,10 @@ namespace Difficalcy.Services
         {
             var resourceNamespace = "Testing.Beatmaps";
             var resourceName = $"{resourceNamespace}.{beatmapId}.osu";
-            var fullResourceName = $"{_resourceAssemblyName}.Resources.{resourceName}";
+            var fullResourceName = $"{resourceAssemblyName}.Resources.{resourceName}";
             var stream = ResourceAssembly.GetManifestResourceStream(fullResourceName);
             if (stream == null)
-                throw new Exception($@"Unable to find resource ""{fullResourceName}"" in assembly ""{_resourceAssemblyName}""");
+                throw new Exception($@"Unable to find resource ""{fullResourceName}"" in assembly ""{resourceAssemblyName}""");
             return stream;
         }
 
@@ -37,7 +30,7 @@ namespace Difficalcy.Services
             get
             {
                 string localPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
-                return Assembly.LoadFrom(Path.Combine(localPath, $"{_resourceAssemblyName}.dll"));
+                return Assembly.LoadFrom(Path.Combine(localPath, $"{resourceAssemblyName}.dll"));
             }
         }
     }

--- a/Difficalcy/Services/WebBeatmapProvider.cs
+++ b/Difficalcy/Services/WebBeatmapProvider.cs
@@ -17,7 +17,7 @@ namespace Difficalcy.Services
 
         public async Task<bool> EnsureBeatmap(string beatmapId)
         {
-            var beatmapPath = Path.Combine(_beatmapDirectory, beatmapId);
+            var beatmapPath = Path.Combine(_beatmapDirectory, $"{beatmapId}.osu");
             if (!File.Exists(beatmapPath))
             {
                 using var response = await _httpClient.GetAsync($"https://osu.ppy.sh/osu/{beatmapId}");

--- a/Difficalcy/Services/WebBeatmapProvider.cs
+++ b/Difficalcy/Services/WebBeatmapProvider.cs
@@ -5,15 +5,10 @@ using Microsoft.Extensions.Configuration;
 
 namespace Difficalcy.Services
 {
-    public class WebBeatmapProvider : IBeatmapProvider
+    public class WebBeatmapProvider(IConfiguration configuration) : IBeatmapProvider
     {
-        private string _beatmapDirectory;
-        private readonly HttpClient _httpClient = new HttpClient();
-
-        public WebBeatmapProvider(IConfiguration configuration)
-        {
-            _beatmapDirectory = configuration["BEATMAP_DIRECTORY"];
-        }
+        private readonly string _beatmapDirectory = configuration["BEATMAP_DIRECTORY"];
+        private readonly HttpClient _httpClient = new();
 
         public async Task<bool> EnsureBeatmap(string beatmapId)
         {

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1,0 +1,19 @@
+# Configuration
+
+difficalcy is designed to be simple to get up and running, so there are no _required_ configurations.
+
+However it would be a good idea to consider these configuration options for a real application deployment.
+
+## Environment Variables
+
+| Environment variable  | Default | Description                                                                                     |
+| --------------------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `REDIS_CONFIGURATION` |         | The address of the redis server to use for beatmap caching. By default, there will be no cache. |
+
+## Docker volumes
+
+By default these paths will use anonymous volumes, but you may want to create and mount named volumes here, to ensure persistent storage, or to share with other containers.
+
+| Path        | Description                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------------- |
+| `/beatmaps` | This is the path where difficalcy will use to cache beatmaps. Beatmaps are stored as `<beatmapid>.osu`. |

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -31,10 +31,10 @@ See [API Reference](./api-reference/index.md) for available endpoints.
 
 difficalcy is available for all four official osu! rulesets:
 
-- osu! - `ghcr.io/syriiin/difficalcy-osu:latest`
-- osu!taiko - `ghcr.io/syriiin/difficalcy-taiko:latest`
-- osu!catch - `ghcr.io/syriiin/difficalcy-catch:latest`
-- osu!mania - `ghcr.io/syriiin/difficalcy-mania:latest`
+- osu! - `ghcr.io/syriiin/difficalcy-osu`
+- osu!taiko - `ghcr.io/syriiin/difficalcy-taiko`
+- osu!catch - `ghcr.io/syriiin/difficalcy-catch`
+- osu!mania - `ghcr.io/syriiin/difficalcy-mania`
 
 See [the github packages](https://github.com/Syriiin?tab=packages&repo_name=difficalcy) for the latest list.
 
@@ -63,20 +63,6 @@ services:
     ports:
       - "5000:80"
 ```
-
-## Configuration
-
-difficalcy is designed to be simple to get up and running, so there are no _required_ configurations.
-
-By default, the beatmap cache will be on an anonymous volume, and there will be no caching for calculations.
-
-### Environment Variables
-
-| Environment variable  | Default | Description                                                                                     |
-| --------------------- | ------- | ----------------------------------------------------------------------------------------------- |
-| `REDIS_CONFIGURATION` |         | The address of the redis server to use for beatmap caching. By default, there will be no cache. |
-
-## Recommended setup
 
 ## How to run a calculation
 
@@ -159,3 +145,35 @@ curl "localhost:5000/api/calculation?BeatmapId=658127&Mods=24&Oks=24&Misses=2&Co
   }
 }
 ```
+
+## Recommended setup
+
+In a real deployment, caching is important, so including a redis instance and persistent volumes for both beatmaps and redis data will help you a lot.
+
+For real deployments, I also recommend you NOT use the `latest` tag, as this could cause issues if there is a major version released.
+You are better off checking for the current latest version in the [releases](https://github.com/Syriiin/difficalcy/releases) and pinning it manually.
+
+```yaml
+services:
+  difficalcy-osu:
+    image: ghcr.io/syriiin/difficalcy-osu:latest
+    environment:
+      - REDIS_CONFIGURATION=cache:6379
+    ports:
+      - 5000:80
+    volumes:
+      - beatmaps:/beatmaps
+    depends_on:
+      - cache
+
+  cache:
+    image: redis:latest
+    volumes:
+      - redis-data:/data
+
+  volumes:
+    beatmaps:
+    redis-data:
+```
+
+See [Configuration](./configuration.md) for a full list of configuration options.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -10,6 +10,7 @@ copyright: |
 nav:
   - index.md
   - getting-started.md
+  - configuration.md
   - API Reference:
     - api-reference/index.md
     - difficalcy-osu: api-reference/difficalcy-osu.md


### PR DESCRIPTION
## Why?

Using the .osu file extension on beatmaps is standard. It was only without them because of legacy reasons through osuchan's history.

## Changes

- Use `.osu` extension on beatmaps
- Fix a bunch of code style issues
- Add configuration page to docs