### PR TITLE
Fix crashing on missing beatmaps

### DIFF
--- a/Difficalcy.Tests/DummyCalculatorServiceTest.cs
+++ b/Difficalcy.Tests/DummyCalculatorServiceTest.cs
@@ -45,7 +45,7 @@ public class DummyCalculatorService(ICache cache) : CalculatorService<DummyScore
     protected override object DeserialiseDifficultyAttributes(string difficultyAttributesJson) =>
         double.Parse(difficultyAttributesJson);
 
-    protected override Task<bool> EnsureBeatmap(string beatmapId) =>
+    protected override Task EnsureBeatmap(string beatmapId) =>
         Task.FromResult(true);
 }
 

--- a/Difficalcy/Services/IBeatmapProvider.cs
+++ b/Difficalcy/Services/IBeatmapProvider.cs
@@ -5,7 +5,7 @@ namespace Difficalcy.Services
 {
     public interface IBeatmapProvider
     {
-        public Task<bool> EnsureBeatmap(string beatmapId);
+        public Task EnsureBeatmap(string beatmapId);
 
         public Stream GetBeatmapStream(string beatmapId);
     }

--- a/Difficalcy/Services/TestBeatmapProvider.cs
+++ b/Difficalcy/Services/TestBeatmapProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 
 namespace Difficalcy.Services
 {
@@ -9,20 +10,22 @@ namespace Difficalcy.Services
     {
         public Task EnsureBeatmap(string beatmapId)
         {
-            var resourceName = $"{resourceAssemblyName}.Resources.{beatmapId}";
-            var info = ResourceAssembly.GetManifestResourceInfo(resourceName);
-            return Task.FromResult(info != null);
+            var resourceName = GetResourceName(beatmapId);
+            _ = ResourceAssembly.GetManifestResourceInfo(resourceName) ?? throw new BadHttpRequestException($"Beatmap not found: {beatmapId}");
+            return Task.CompletedTask;
         }
 
         public Stream GetBeatmapStream(string beatmapId)
         {
+            var resourceName = GetResourceName(beatmapId);
+            return ResourceAssembly.GetManifestResourceStream(resourceName);
+        }
+
+        private string GetResourceName(string beatmapId)
+        {
             var resourceNamespace = "Testing.Beatmaps";
             var resourceName = $"{resourceNamespace}.{beatmapId}.osu";
-            var fullResourceName = $"{resourceAssemblyName}.Resources.{resourceName}";
-            var stream = ResourceAssembly.GetManifestResourceStream(fullResourceName);
-            if (stream == null)
-                throw new Exception($@"Unable to find resource ""{fullResourceName}"" in assembly ""{resourceAssemblyName}""");
-            return stream;
+            return $"{resourceAssemblyName}.Resources.{resourceName}";
         }
 
         private Assembly ResourceAssembly

--- a/Difficalcy/Services/TestBeatmapProvider.cs
+++ b/Difficalcy/Services/TestBeatmapProvider.cs
@@ -7,7 +7,7 @@ namespace Difficalcy.Services
 {
     public class TestBeatmapProvider(string resourceAssemblyName) : IBeatmapProvider
     {
-        public Task<bool> EnsureBeatmap(string beatmapId)
+        public Task EnsureBeatmap(string beatmapId)
         {
             var resourceName = $"{resourceAssemblyName}.Resources.{beatmapId}";
             var info = ResourceAssembly.GetManifestResourceInfo(resourceName);


### PR DESCRIPTION
## Why?

Http 500 errors should be avoided wherever possible.

## Changes

- Throw bad request exception if beatmap not available
- Check for empty beatmap files on download