### PR TITLE
Add DOWNLOAD_MISSING_BEATMAPS env var

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "swashbuckle.aspnetcore.cli": {
+      "version": "6.6.1",
+      "commands": [
+        "swagger"
+      ]
+    }
+  }
+}

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -12,3 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: make test-e2e
+
+  check-api-reference:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: make check-api-reference

--- a/Difficalcy/Controllers/CalculatorController.cs
+++ b/Difficalcy/Controllers/CalculatorController.cs
@@ -33,7 +33,14 @@ namespace Difficalcy.Controllers
         [HttpGet("calculation")]
         public async Task<ActionResult<TCalculation>> GetCalculation([FromQuery] TScore score)
         {
-            return Ok(await calculatorService.GetCalculation(score));
+            try
+            {
+                return Ok(await calculatorService.GetCalculation(score));
+            }
+            catch (BeatmapNotFoundException e)
+            {
+                return BadRequest(new { error = e.Message });
+            }
         }
 
         /// <summary>
@@ -43,7 +50,14 @@ namespace Difficalcy.Controllers
         [Consumes("application/json")]
         public async Task<ActionResult<TCalculation[]>> GetCalculationBatch([FromBody] TScore[] scores)
         {
-            return Ok(await Task.WhenAll(scores.Select(score => calculatorService.GetCalculation(score))));
+            try
+            {
+                return Ok(await Task.WhenAll(scores.Select(calculatorService.GetCalculation)));
+            }
+            catch (BeatmapNotFoundException e)
+            {
+                return BadRequest(new { error = e.Message });
+            }
         }
     }
 }

--- a/Difficalcy/Services/BeatmapNotFoundException.cs
+++ b/Difficalcy/Services/BeatmapNotFoundException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Difficalcy.Services
+{
+    public class BeatmapNotFoundException(string beatmapId) : Exception($"Beatmap {beatmapId} not found")
+    {
+    }
+}

--- a/Difficalcy/Services/TestBeatmapProvider.cs
+++ b/Difficalcy/Services/TestBeatmapProvider.cs
@@ -1,8 +1,6 @@
-using System;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 
 namespace Difficalcy.Services
 {
@@ -11,7 +9,7 @@ namespace Difficalcy.Services
         public Task EnsureBeatmap(string beatmapId)
         {
             var resourceName = GetResourceName(beatmapId);
-            _ = ResourceAssembly.GetManifestResourceInfo(resourceName) ?? throw new BadHttpRequestException($"Beatmap not found: {beatmapId}");
+            _ = ResourceAssembly.GetManifestResourceInfo(resourceName) ?? throw new BeatmapNotFoundException(beatmapId);
             return Task.CompletedTask;
         }
 

--- a/Difficalcy/Services/WebBeatmapProvider.cs
+++ b/Difficalcy/Services/WebBeatmapProvider.cs
@@ -9,6 +9,7 @@ namespace Difficalcy.Services
     public class WebBeatmapProvider(IConfiguration configuration) : IBeatmapProvider
     {
         private readonly string _beatmapDirectory = configuration["BEATMAP_DIRECTORY"];
+        private readonly string _downloadMissingBeatmaps = configuration["DOWNLOAD_MISSING_BEATMAPS"];
         private readonly HttpClient _httpClient = new();
 
         public async Task EnsureBeatmap(string beatmapId)
@@ -16,6 +17,9 @@ namespace Difficalcy.Services
             var beatmapPath = GetBeatmapPath(beatmapId);
             if (!File.Exists(beatmapPath))
             {
+                if (_downloadMissingBeatmaps != "true")
+                    throw new BadHttpRequestException("Beatmap not found");
+
                 using var response = await _httpClient.GetAsync($"https://osu.ppy.sh/osu/{beatmapId}");
                 if (!response.IsSuccessStatusCode || response.Content.Headers.ContentLength == 0)
                     throw new BadHttpRequestException("Beatmap not found");

--- a/Difficalcy/Services/WebBeatmapProvider.cs
+++ b/Difficalcy/Services/WebBeatmapProvider.cs
@@ -17,14 +17,13 @@ namespace Difficalcy.Services
             if (!File.Exists(beatmapPath))
             {
                 using var response = await _httpClient.GetAsync($"https://osu.ppy.sh/osu/{beatmapId}");
-                if (!response.IsSuccessStatusCode)
+                if (!response.IsSuccessStatusCode || response.Content.Headers.ContentLength == 0)
                     throw new BadHttpRequestException("Beatmap not found");
 
                 using var fs = new FileStream(beatmapPath, FileMode.CreateNew);
+                await response.Content.CopyToAsync(fs);
                 if (fs.Length == 0)
                     throw new BadHttpRequestException("Beatmap not found");
-
-                await response.Content.CopyToAsync(fs);
             }
         }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ LABEL org.opencontainers.image.source https://github.com/Syriiin/difficalcy
 
 WORKDIR /app
 EXPOSE 80
-ENV ASPNETCORE_URLS=http://+:80
-ENV ASPNETCORE_ENVIRONMENT=Production
-ENV BEATMAP_DIRECTORY=/beatmaps
+ENV ASPNETCORE_URLS="http://+:80"
+ENV ASPNETCORE_ENVIRONMENT="Production"
+ENV BEATMAP_DIRECTORY="/beatmaps"
+ENV DOWNLOAD_MISSING_BEATMAPS="true"
 
 VOLUME ${BEATMAP_DIRECTORY}
 # chmod 777 so that this volume can be read/written by other containers that might use different uids

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ start-dev: build-dev	## Starts development environment
 clean-dev:	## Cleans development environment
 	$(COMPOSE_APP_DEV) down --remove-orphans
 
-update-openapi-schemas:	## Updates OpenAPI schemas in docs site
-	curl localhost:5000/swagger/v1/swagger.json -o docs/docs/api-reference/difficalcy-osu.json
-	curl localhost:5001/swagger/v1/swagger.json -o docs/docs/api-reference/difficalcy-taiko.json
-	curl localhost:5002/swagger/v1/swagger.json -o docs/docs/api-reference/difficalcy-catch.json
-	curl localhost:5003/swagger/v1/swagger.json -o docs/docs/api-reference/difficalcy-mania.json
+update-api-reference: start-dev	## Updates OpenAPI schemas in docs site
+	@scripts/update-api-reference.sh
+
+check-api-reference: start-dev ## Checks OpenAPI schemas are updated
+	@scripts/check-api-reference.sh
 
 build-docs:	## Builds documentation site
 	$(COMPOSE_RUN_DOCS) build --strict --clean

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ start-dev: build-dev	## Starts development environment
 clean-dev:	## Cleans development environment
 	$(COMPOSE_APP_DEV) down --remove-orphans
 
-update-api-reference: start-dev	## Updates OpenAPI schemas in docs site
-	@scripts/update-api-reference.sh
+update-api-reference:	## Updates OpenAPI schemas in docs site
+	$(COMPOSE_TOOLING_RUN) scripts/update-api-reference.sh
 
-check-api-reference: start-dev ## Checks OpenAPI schemas are updated
-	@scripts/check-api-reference.sh
+check-api-reference: ## Checks OpenAPI schemas are updated
+	$(COMPOSE_TOOLING_RUN) scripts/check-api-reference.sh
 
 build-docs:	## Builds documentation site
 	$(COMPOSE_RUN_DOCS) build --strict --clean

--- a/compose.tooling.yaml
+++ b/compose.tooling.yaml
@@ -3,3 +3,5 @@ services:
     build:
       context: .
       dockerfile: ./tooling.Dockerfile
+    volumes:
+      - .:/app

--- a/docs/docs/api-reference/difficalcy-catch.json
+++ b/docs/docs/api-reference/difficalcy-catch.json
@@ -12,7 +12,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -37,8 +37,7 @@
               "maximum": 2147483647,
               "minimum": 0,
               "type": "integer",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -58,8 +57,7 @@
               "maximum": 2147483647,
               "minimum": 0,
               "type": "integer",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -69,8 +67,7 @@
               "maximum": 2147483647,
               "minimum": 0,
               "type": "integer",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -94,7 +91,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -118,15 +115,14 @@
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/CatchScore"
-                },
-                "nullable": true
+                }
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -170,26 +166,6 @@
         },
         "additionalProperties": false
       },
-      "CatchDifficulty": {
-        "type": "object",
-        "properties": {
-          "total": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "additionalProperties": false
-      },
-      "CatchPerformance": {
-        "type": "object",
-        "properties": {
-          "total": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "additionalProperties": false
-      },
       "CatchCalculation": {
         "type": "object",
         "properties": {
@@ -210,6 +186,26 @@
         },
         "additionalProperties": false
       },
+      "CatchDifficulty": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CatchPerformance": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
       "CatchScore": {
         "required": [
           "beatmapId"
@@ -217,6 +213,7 @@
         "type": "object",
         "properties": {
           "beatmapId": {
+            "minLength": 1,
             "type": "string"
           },
           "mods": {

--- a/docs/docs/api-reference/difficalcy-mania.json
+++ b/docs/docs/api-reference/difficalcy-mania.json
@@ -12,7 +12,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -101,7 +101,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -125,15 +125,14 @@
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/ManiaScore"
-                },
-                "nullable": true
+                }
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -177,6 +176,22 @@
         },
         "additionalProperties": false
       },
+      "ManiaCalculation": {
+        "type": "object",
+        "properties": {
+          "difficulty": {
+            "$ref": "#/components/schemas/ManiaDifficulty"
+          },
+          "performance": {
+            "$ref": "#/components/schemas/ManiaPerformance"
+          },
+          "accuracy": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
       "ManiaDifficulty": {
         "type": "object",
         "properties": {
@@ -201,22 +216,6 @@
         },
         "additionalProperties": false
       },
-      "ManiaCalculation": {
-        "type": "object",
-        "properties": {
-          "difficulty": {
-            "$ref": "#/components/schemas/ManiaDifficulty"
-          },
-          "performance": {
-            "$ref": "#/components/schemas/ManiaPerformance"
-          },
-          "accuracy": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "additionalProperties": false
-      },
       "ManiaScore": {
         "required": [
           "beatmapId"
@@ -224,6 +223,7 @@
         "type": "object",
         "properties": {
           "beatmapId": {
+            "minLength": 1,
             "type": "string"
           },
           "mods": {

--- a/docs/docs/api-reference/difficalcy-osu.json
+++ b/docs/docs/api-reference/difficalcy-osu.json
@@ -12,7 +12,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -37,8 +37,7 @@
               "maximum": 2147483647,
               "minimum": 0,
               "type": "integer",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -92,7 +91,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -116,15 +115,14 @@
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/OsuScore"
-                },
-                "nullable": true
+                }
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -164,6 +162,26 @@
           "calculatorUrl": {
             "type": "string",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "OsuCalculation": {
+        "type": "object",
+        "properties": {
+          "difficulty": {
+            "$ref": "#/components/schemas/OsuDifficulty"
+          },
+          "performance": {
+            "$ref": "#/components/schemas/OsuPerformance"
+          },
+          "accuracy": {
+            "type": "number",
+            "format": "double"
+          },
+          "combo": {
+            "type": "number",
+            "format": "double"
           }
         },
         "additionalProperties": false
@@ -216,26 +234,6 @@
         },
         "additionalProperties": false
       },
-      "OsuCalculation": {
-        "type": "object",
-        "properties": {
-          "difficulty": {
-            "$ref": "#/components/schemas/OsuDifficulty"
-          },
-          "performance": {
-            "$ref": "#/components/schemas/OsuPerformance"
-          },
-          "accuracy": {
-            "type": "number",
-            "format": "double"
-          },
-          "combo": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "additionalProperties": false
-      },
       "OsuScore": {
         "required": [
           "beatmapId"
@@ -243,6 +241,7 @@
         "type": "object",
         "properties": {
           "beatmapId": {
+            "minLength": 1,
             "type": "string"
           },
           "mods": {

--- a/docs/docs/api-reference/difficalcy-taiko.json
+++ b/docs/docs/api-reference/difficalcy-taiko.json
@@ -12,7 +12,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -37,8 +37,7 @@
               "maximum": 2147483647,
               "minimum": 0,
               "type": "integer",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -82,7 +81,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -106,15 +105,14 @@
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/TaikoScore"
-                },
-                "nullable": true
+                }
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -154,6 +152,26 @@
           "calculatorUrl": {
             "type": "string",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TaikoCalculation": {
+        "type": "object",
+        "properties": {
+          "difficulty": {
+            "$ref": "#/components/schemas/TaikoDifficulty"
+          },
+          "performance": {
+            "$ref": "#/components/schemas/TaikoPerformance"
+          },
+          "accuracy": {
+            "type": "number",
+            "format": "double"
+          },
+          "combo": {
+            "type": "number",
+            "format": "double"
           }
         },
         "additionalProperties": false
@@ -198,26 +216,6 @@
         },
         "additionalProperties": false
       },
-      "TaikoCalculation": {
-        "type": "object",
-        "properties": {
-          "difficulty": {
-            "$ref": "#/components/schemas/TaikoDifficulty"
-          },
-          "performance": {
-            "$ref": "#/components/schemas/TaikoPerformance"
-          },
-          "accuracy": {
-            "type": "number",
-            "format": "double"
-          },
-          "combo": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "additionalProperties": false
-      },
       "TaikoScore": {
         "required": [
           "beatmapId"
@@ -225,6 +223,7 @@
         "type": "object",
         "properties": {
           "beatmapId": {
+            "minLength": 1,
             "type": "string"
           },
           "mods": {

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -6,9 +6,10 @@ However it would be a good idea to consider these configuration options for a re
 
 ## Environment Variables
 
-| Environment variable  | Default | Description                                                                                     |
-| --------------------- | ------- | ----------------------------------------------------------------------------------------------- |
-| `REDIS_CONFIGURATION` |         | The address of the redis server to use for beatmap caching. By default, there will be no cache. |
+| Environment variable        | Default | Description                                                                                     |
+| --------------------------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `REDIS_CONFIGURATION`       |         | The address of the redis server to use for beatmap caching. By default, there will be no cache. |
+| `DOWNLOAD_MISSING_BEATMAPS` | true    | Whether or not to attempt to download missing beatmaps.                                         |
 
 ## Docker volumes
 

--- a/scripts/check-api-reference.sh
+++ b/scripts/check-api-reference.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+diff -q docs/docs/api-reference/difficalcy-osu.json <(curl --silent localhost:5000/swagger/v1/swagger.json)
+diff -q docs/docs/api-reference/difficalcy-taiko.json <(curl --silent localhost:5001/swagger/v1/swagger.json)
+diff -q docs/docs/api-reference/difficalcy-catch.json <(curl --silent localhost:5002/swagger/v1/swagger.json)
+diff -q docs/docs/api-reference/difficalcy-mania.json <(curl --silent localhost:5003/swagger/v1/swagger.json)

--- a/scripts/check-api-reference.sh
+++ b/scripts/check-api-reference.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-diff -q docs/docs/api-reference/difficalcy-osu.json <(curl --silent localhost:5000/swagger/v1/swagger.json)
-diff -q docs/docs/api-reference/difficalcy-taiko.json <(curl --silent localhost:5001/swagger/v1/swagger.json)
-diff -q docs/docs/api-reference/difficalcy-catch.json <(curl --silent localhost:5002/swagger/v1/swagger.json)
-diff -q docs/docs/api-reference/difficalcy-mania.json <(curl --silent localhost:5003/swagger/v1/swagger.json)
+dotnet build
+
+diff -q docs/docs/api-reference/difficalcy-osu.json <(dotnet tool run swagger tofile Difficalcy.Osu/bin/Debug/net8.0/Difficalcy.Osu.dll v1)
+diff -q docs/docs/api-reference/difficalcy-taiko.json <(dotnet tool run swagger tofile Difficalcy.Taiko/bin/Debug/net8.0/Difficalcy.Taiko.dll v1)
+diff -q docs/docs/api-reference/difficalcy-catch.json <(dotnet tool run swagger tofile Difficalcy.Catch/bin/Debug/net8.0/Difficalcy.Catch.dll v1)
+diff -q docs/docs/api-reference/difficalcy-mania.json <(dotnet tool run swagger tofile Difficalcy.Mania/bin/Debug/net8.0/Difficalcy.Mania.dll v1)

--- a/scripts/update-api-reference.sh
+++ b/scripts/update-api-reference.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-curl localhost:5000/swagger/v1/swagger.json -o docs/docs/api-reference/difficalcy-osu.json
-curl localhost:5001/swagger/v1/swagger.json -o docs/docs/api-reference/difficalcy-taiko.json
-curl localhost:5002/swagger/v1/swagger.json -o docs/docs/api-reference/difficalcy-catch.json
-curl localhost:5003/swagger/v1/swagger.json -o docs/docs/api-reference/difficalcy-mania.json
+dotnet build
+
+dotnet tool run swagger tofile Difficalcy.Osu/bin/Debug/net8.0/Difficalcy.Osu.dll v1 > docs/docs/api-reference/difficalcy-osu.json
+dotnet tool run swagger tofile Difficalcy.Taiko/bin/Debug/net8.0/Difficalcy.Taiko.dll v1 > docs/docs/api-reference/difficalcy-taiko.json
+dotnet tool run swagger tofile Difficalcy.Catch/bin/Debug/net8.0/Difficalcy.Catch.dll v1 > docs/docs/api-reference/difficalcy-catch.json
+dotnet tool run swagger tofile Difficalcy.Mania/bin/Debug/net8.0/Difficalcy.Mania.dll v1 > docs/docs/api-reference/difficalcy-mania.json

--- a/scripts/update-api-reference.sh
+++ b/scripts/update-api-reference.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+curl localhost:5000/swagger/v1/swagger.json -o docs/docs/api-reference/difficalcy-osu.json
+curl localhost:5001/swagger/v1/swagger.json -o docs/docs/api-reference/difficalcy-taiko.json
+curl localhost:5002/swagger/v1/swagger.json -o docs/docs/api-reference/difficalcy-catch.json
+curl localhost:5003/swagger/v1/swagger.json -o docs/docs/api-reference/difficalcy-mania.json

--- a/tooling.Dockerfile
+++ b/tooling.Dockerfile
@@ -8,6 +8,10 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
 
 WORKDIR /app
 
+COPY .config/dotnet-tools.json ./.config/
+
+RUN dotnet tool restore
+
 COPY Difficalcy.sln .
 COPY Difficalcy/Difficalcy.csproj ./Difficalcy/
 COPY Difficalcy.Catch/Difficalcy.Catch.csproj ./Difficalcy.Catch/


### PR DESCRIPTION
## Why?

We want to option to have difficalcy rely on an existing mounted beatmap store exclusively.

## Changes

- Add `DOWNLOAD_MISSING_BEATMAPS` env var
- Fix empty beatmap check breaking all downloads
- Use custom exception for missing beatmaps
- Add `check-api-reference` command and CI action
- Use `Swashbuckle.AspNetCore.Cli` to generate api reference schemas