### PR TITLE
Implement better batching

### DIFF
--- a/Difficalcy.Catch.Tests/Difficalcy.Catch.Tests.csproj
+++ b/Difficalcy.Catch.Tests/Difficalcy.Catch.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Difficalcy.Catch/Difficalcy.Catch.csproj
+++ b/Difficalcy.Catch/Difficalcy.Catch.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.412.1" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.412.1" /> <!-- required for convert support -->
+    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.523.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.523.0" /> <!-- required for convert support -->
   </ItemGroup>
 
   <ItemGroup>

--- a/Difficalcy.Catch/Services/CatchCalculatorService.cs
+++ b/Difficalcy.Catch/Services/CatchCalculatorService.cs
@@ -43,10 +43,10 @@ namespace Difficalcy.Catch.Services
             await beatmapProvider.EnsureBeatmap(beatmapId);
         }
 
-        protected override (object, string) CalculateDifficultyAttributes(CatchScore score)
+        protected override (object, string) CalculateDifficultyAttributes(string beatmapId, int bitMods)
         {
-            var workingBeatmap = GetWorkingBeatmap(score.BeatmapId);
-            var mods = CatchRuleset.ConvertFromLegacyMods((LegacyMods)score.Mods).ToArray();
+            var workingBeatmap = GetWorkingBeatmap(beatmapId);
+            var mods = CatchRuleset.ConvertFromLegacyMods((LegacyMods)bitMods).ToArray();
 
             var difficultyCalculator = CatchRuleset.CreateDifficultyCalculator(workingBeatmap);
             var difficultyAttributes = difficultyCalculator.Calculate(mods) as CatchDifficultyAttributes;

--- a/Difficalcy.Mania.Tests/Difficalcy.Mania.Tests.csproj
+++ b/Difficalcy.Mania.Tests/Difficalcy.Mania.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Difficalcy.Mania/Difficalcy.Mania.csproj
+++ b/Difficalcy.Mania/Difficalcy.Mania.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.412.1" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.412.1" /> <!-- required for convert support -->
+    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.523.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.523.0" /> <!-- required for convert support -->
   </ItemGroup>
 
   <ItemGroup>

--- a/Difficalcy.Mania/Services/ManiaCalculatorService.cs
+++ b/Difficalcy.Mania/Services/ManiaCalculatorService.cs
@@ -43,10 +43,10 @@ namespace Difficalcy.Mania.Services
             await _beatmapProvider.EnsureBeatmap(beatmapId);
         }
 
-        protected override (object, string) CalculateDifficultyAttributes(ManiaScore score)
+        protected override (object, string) CalculateDifficultyAttributes(string beatmapId, int bitMods)
         {
-            var workingBeatmap = GetWorkingBeatmap(score.BeatmapId);
-            var mods = ManiaRuleset.ConvertFromLegacyMods((LegacyMods)score.Mods).ToArray();
+            var workingBeatmap = GetWorkingBeatmap(beatmapId);
+            var mods = ManiaRuleset.ConvertFromLegacyMods((LegacyMods)bitMods).ToArray();
 
             var difficultyCalculator = ManiaRuleset.CreateDifficultyCalculator(workingBeatmap);
             var difficultyAttributes = difficultyCalculator.Calculate(mods) as ManiaDifficultyAttributes;

--- a/Difficalcy.Osu.Tests/Difficalcy.Osu.Tests.csproj
+++ b/Difficalcy.Osu.Tests/Difficalcy.Osu.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Difficalcy.Osu/Difficalcy.Osu.csproj
+++ b/Difficalcy.Osu/Difficalcy.Osu.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.412.1" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.523.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Difficalcy.Osu/Services/OsuCalculatorService.cs
+++ b/Difficalcy.Osu/Services/OsuCalculatorService.cs
@@ -41,10 +41,10 @@ namespace Difficalcy.Osu.Services
             await beatmapProvider.EnsureBeatmap(beatmapId);
         }
 
-        protected override (object, string) CalculateDifficultyAttributes(OsuScore score)
+        protected override (object, string) CalculateDifficultyAttributes(string beatmapId, int bitMods)
         {
-            var workingBeatmap = GetWorkingBeatmap(score.BeatmapId);
-            var mods = OsuRuleset.ConvertFromLegacyMods((LegacyMods)score.Mods).ToArray();
+            var workingBeatmap = GetWorkingBeatmap(beatmapId);
+            var mods = OsuRuleset.ConvertFromLegacyMods((LegacyMods)bitMods).ToArray();
 
             var difficultyCalculator = OsuRuleset.CreateDifficultyCalculator(workingBeatmap);
             var difficultyAttributes = difficultyCalculator.Calculate(mods) as OsuDifficultyAttributes;

--- a/Difficalcy.Taiko.Tests/Difficalcy.Taiko.Tests.csproj
+++ b/Difficalcy.Taiko.Tests/Difficalcy.Taiko.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Difficalcy.Taiko/Difficalcy.Taiko.csproj
+++ b/Difficalcy.Taiko/Difficalcy.Taiko.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.412.1" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.412.1" /> <!-- required for convert support -->
+    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.523.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.523.0" /> <!-- required for convert support -->
   </ItemGroup>
 
   <ItemGroup>

--- a/Difficalcy.Taiko/Services/TaikoCalculatorService.cs
+++ b/Difficalcy.Taiko/Services/TaikoCalculatorService.cs
@@ -43,10 +43,10 @@ namespace Difficalcy.Taiko.Services
             await _beatmapProvider.EnsureBeatmap(beatmapId);
         }
 
-        protected override (object, string) CalculateDifficultyAttributes(TaikoScore score)
+        protected override (object, string) CalculateDifficultyAttributes(string beatmapId, int bitMods)
         {
-            var workingBeatmap = GetWorkingBeatmap(score.BeatmapId);
-            var mods = TaikoRuleset.ConvertFromLegacyMods((LegacyMods)score.Mods).ToArray();
+            var workingBeatmap = GetWorkingBeatmap(beatmapId);
+            var mods = TaikoRuleset.ConvertFromLegacyMods((LegacyMods)bitMods).ToArray();
 
             var difficultyCalculator = TaikoRuleset.CreateDifficultyCalculator(workingBeatmap);
             var difficultyAttributes = difficultyCalculator.Calculate(mods) as TaikoDifficultyAttributes;

--- a/Difficalcy.Tests/Difficalcy.Tests.csproj
+++ b/Difficalcy.Tests/Difficalcy.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Difficalcy.Tests/DummyCalculatorServiceTest.cs
+++ b/Difficalcy.Tests/DummyCalculatorServiceTest.cs
@@ -11,7 +11,68 @@ public class DummyCalculatorServiceTest : CalculatorServiceTest<DummyScore, Dumm
     [InlineData(15, 1500, "test 1", 150)]
     [InlineData(10, 1000, "test 2", 100)]
     public void Test(double expectedDifficultyTotal, double expectedPerformanceTotal, string beatmapId, int mods)
-        => TestGetCalculationReturnsCorrectValues(expectedDifficultyTotal, expectedPerformanceTotal, new DummyScore { BeatmapId = beatmapId, Mods = mods });
+        => TestGetCalculationReturnsCorrectValues(expectedDifficultyTotal, expectedPerformanceTotal, new DummyScore { BeatmapId = beatmapId, Mods = mods, Points = 100 });
+
+    [Fact]
+    public async Task TestGetCalculationBatchReturnsCorrectValuesInOrder()
+    {
+        // values are intentionally in a random order to ensure unique beatmap grouping doesnt break return ordering
+        var scores = new[]
+        {
+            new DummyScore { BeatmapId = "test 1", Mods = 200, Points = 200 }, // 3
+            new DummyScore { BeatmapId = "test 2", Mods = 300, Points = 100 }, // 4
+            new DummyScore { BeatmapId = "test 2", Mods = 300, Points = 200 }, // 5
+            new DummyScore { BeatmapId = "test 3", Mods = 500, Points = 200 }, // 9
+            new DummyScore { BeatmapId = "test 2", Mods = 400, Points = 200 }, // 7
+            new DummyScore { BeatmapId = "test 1", Mods = 200, Points = 100 }, // 2
+            new DummyScore { BeatmapId = "test 3", Mods = 600, Points = 100 }, // 10
+            new DummyScore { BeatmapId = "test 2", Mods = 400, Points = 100 }, // 6
+            new DummyScore { BeatmapId = "test 3", Mods = 500, Points = 100 }, // 8
+            new DummyScore { BeatmapId = "test 1", Mods = 100, Points = 200 }, // 1
+            new DummyScore { BeatmapId = "test 3", Mods = 600, Points = 200 }, // 11
+            new DummyScore { BeatmapId = "test 1", Mods = 100, Points = 100 }, // 0
+        };
+
+        var calculations = (await CalculatorService.GetCalculationBatch(scores)).ToArray();
+
+        Assert.Equal(12, calculations.Length);
+
+        Assert.Equal(20, calculations[0].Difficulty.Total);         // 3
+        Assert.Equal(4000, calculations[0].Performance.Total);
+
+        Assert.Equal(30, calculations[1].Difficulty.Total);         // 4
+        Assert.Equal(3000, calculations[1].Performance.Total);
+
+        Assert.Equal(30, calculations[2].Difficulty.Total);         // 5
+        Assert.Equal(6000, calculations[2].Performance.Total);
+
+        Assert.Equal(50, calculations[3].Difficulty.Total);         // 9
+        Assert.Equal(10000, calculations[3].Performance.Total);
+
+        Assert.Equal(40, calculations[4].Difficulty.Total);         // 7
+        Assert.Equal(8000, calculations[4].Performance.Total);
+
+        Assert.Equal(20, calculations[5].Difficulty.Total);         // 2
+        Assert.Equal(2000, calculations[5].Performance.Total);
+
+        Assert.Equal(60, calculations[6].Difficulty.Total);         // 10
+        Assert.Equal(6000, calculations[6].Performance.Total);
+
+        Assert.Equal(40, calculations[7].Difficulty.Total);         // 6
+        Assert.Equal(4000, calculations[7].Performance.Total);
+
+        Assert.Equal(50, calculations[8].Difficulty.Total);         // 8
+        Assert.Equal(5000, calculations[8].Performance.Total);
+
+        Assert.Equal(10, calculations[9].Difficulty.Total);         // 1
+        Assert.Equal(2000, calculations[9].Performance.Total);
+
+        Assert.Equal(60, calculations[10].Difficulty.Total);        // 11
+        Assert.Equal(12000, calculations[10].Performance.Total);
+
+        Assert.Equal(10, calculations[11].Difficulty.Total);        // 0
+        Assert.Equal(1000, calculations[11].Performance.Total);
+    }
 }
 
 /// <summary>
@@ -29,9 +90,9 @@ public class DummyCalculatorService(ICache cache) : CalculatorService<DummyScore
             CalculatorUrl = $"not.a.real.url"
         };
 
-    protected override (object, string) CalculateDifficultyAttributes(DummyScore score)
+    protected override (object, string) CalculateDifficultyAttributes(string beatmapId, int mods)
     {
-        var difficulty = score.Mods / 10.0;
+        var difficulty = mods / 10.0;
         return (difficulty, difficulty.ToString());
     }
 
@@ -39,7 +100,7 @@ public class DummyCalculatorService(ICache cache) : CalculatorService<DummyScore
         new()
         {
             Difficulty = new DummyDifficulty() { Total = (double)difficultyAttributes },
-            Performance = new DummyPerformance() { Total = (double)difficultyAttributes * 100 }
+            Performance = new DummyPerformance() { Total = (double)difficultyAttributes * score.Points }
         };
 
     protected override object DeserialiseDifficultyAttributes(string difficultyAttributesJson) =>
@@ -49,7 +110,10 @@ public class DummyCalculatorService(ICache cache) : CalculatorService<DummyScore
         Task.FromResult(true);
 }
 
-public record DummyScore : Score { }
+public record DummyScore : Score
+{
+    public int Points { get; init; }
+}
 public record DummyDifficulty : Difficulty { }
 public record DummyPerformance : Performance { }
 public record DummyCalculation : Calculation<DummyDifficulty, DummyPerformance> { }

--- a/Difficalcy/Controllers/CalculatorController.cs
+++ b/Difficalcy/Controllers/CalculatorController.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Threading.Tasks;
 using Difficalcy.Models;
 using Difficalcy.Services;
@@ -52,7 +51,7 @@ namespace Difficalcy.Controllers
         {
             try
             {
-                return Ok(await Task.WhenAll(scores.Select(calculatorService.GetCalculation)));
+                return Ok(await calculatorService.GetCalculationBatch(scores));
             }
             catch (BeatmapNotFoundException e)
             {

--- a/Difficalcy/Difficalcy.csproj
+++ b/Difficalcy/Difficalcy.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
   </ItemGroup>
 


### PR DESCRIPTION
## Why?

Batch calculations are very naive at the moment.
It effectively is the same process as doing single calculations, but using a single HTTP request.
In the case where there are many hits to the cache/recalculations of the same beatmap/mod, we are wasting a lot of effort.
This PR implement smarter batching by grouping scores by beatmap/mods and processing them in groups to share difficulty calculations.

## Changes

- Update a bunch of deps
- Implement better batching
- Add test to ensure better batching doesn't break result ordering

## Breaking changes

- Update `CalculatorService.CalculateDifficultyAttributes` method signature
```diff
- protected abstract (object, string) CalculateDifficultyAttributes(TScore score);
+ protected abstract (object, string) CalculateDifficultyAttributes(string beatmapId, int mods);
```