### PR TITLE
Handle zero object maps by defaulting acc to 100%

### DIFF
--- a/Difficalcy.Catch/Services/CatchCalculatorService.cs
+++ b/Difficalcy.Catch/Services/CatchCalculatorService.cs
@@ -134,6 +134,9 @@ namespace Difficalcy.Catch.Services
             double hits = statistics[HitResult.Great] + statistics[HitResult.LargeTickHit] + statistics[HitResult.SmallTickHit];
             double total = hits + statistics[HitResult.Miss] + statistics[HitResult.SmallTickMiss];
 
+            if (total == 0)
+                return 1;
+
             return hits / total;
         }
 

--- a/Difficalcy.Mania/Services/ManiaCalculatorService.cs
+++ b/Difficalcy.Mania/Services/ManiaCalculatorService.cs
@@ -127,6 +127,9 @@ namespace Difficalcy.Mania.Services
             var countMiss = statistics[HitResult.Miss];
             var total = countPerfect + countGreat + countGood + countOk + countMeh + countMiss;
 
+            if (total == 0)
+                return 1;
+
             return (double)((6 * countPerfect) + (6 * countGreat) + (4 * countGood) + (2 * countOk) + countMeh) / (6 * total);
         }
 

--- a/Difficalcy.Osu/Services/OsuCalculatorService.cs
+++ b/Difficalcy.Osu/Services/OsuCalculatorService.cs
@@ -132,6 +132,9 @@ namespace Difficalcy.Osu.Services
             var countMiss = statistics[HitResult.Miss];
             var total = countGreat + countOk + countMeh + countMiss;
 
+            if (total == 0)
+                return 1;
+
             return (double)((6 * countGreat) + (2 * countOk) + countMeh) / (6 * total);
         }
 

--- a/Difficalcy.Taiko/Services/TaikoCalculatorService.cs
+++ b/Difficalcy.Taiko/Services/TaikoCalculatorService.cs
@@ -128,6 +128,9 @@ namespace Difficalcy.Taiko.Services
             var countMiss = statistics[HitResult.Miss];
             var total = countGreat + countOk + countMiss;
 
+            if (total == 0)
+                return 1;
+
             return (double)((2 * countGreat) + countOk) / (2 * total);
         }
 


### PR DESCRIPTION
## Why?

Currently this results in a NaN due to the division by zero.
100% was chosen instead of 0% as this is consistent with how the new osu site handles such cases.
For example https://osu.ppy.sh/beatmapsets/371675#taiko/814198

## Changes

- Default to 100% accuracy if a score has zero objects