### PR TITLE
Add xunit group for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
       - "/Difficalcy.Tests"
     schedule:
       interval: "daily"
+    groups:
+      xunit:
+        applies-to: version-updates
+        patterns:
+          - "xunit"


### PR DESCRIPTION
## Why?

Updates like [this](https://github.com/Syriiin/difficalcy/pull/26) fail until the other deps like [this](https://github.com/Syriiin/difficalcy/pull/25) are merged

## Changes

- Group xunit deps when making dependabot updates