### PR TITLE
Add reset-dev command to fully reset dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ start-dev: build-dev	## Starts development environment
 clean-dev:	## Cleans development environment
 	$(COMPOSE_APP_DEV) down --remove-orphans
 
+reset-dev:	## Resets development environment
+	$(COMPOSE_APP_DEV) down --remove-orphans --volumes
+
 update-api-reference:	## Updates OpenAPI schemas in docs site
 	$(COMPOSE_TOOLING_RUN) scripts/update-api-reference.sh
 


### PR DESCRIPTION
## Why?

When updating to a new version and fixing issues, the cache can be polluted by bad results.
This can cause the e2e test to fail and be confusing so a convenient script to reset to zero is nice.

## Changes

- Add `make reset-dev` command