### PR TITLE
Add Microsoft.NET.Test.Sdk to test-tools group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,11 @@ updates:
     schedule:
       interval: "daily"
     groups:
-      xunit:
+      test-tools:
         applies-to: version-updates
         patterns:
           - "xunit*"
+          - "Microsoft.NET.Test.Sdk"
       osu-rulesets:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
## Why?

This is another package that gets confused when done one at a time.

## Changes

- Add `Microsoft.NET.Test.Sdk` to `test-tools` dependabot group