### PR TITLE
Enable dependabot updates for pip in /docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
         applies-to: version-updates
         patterns:
           - "ppy.osu.Game.Rulesets*"
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -18,3 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: make check-api-reference
+
+  check-docs-build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: make build-docs


### PR DESCRIPTION
## Why?

Our docs deserve to be updated too.

## Changes

- Enable dependabot for `/docs` with the `pip` ecosystem