### PR TITLE
Add simple logging for beatmap downloads

### DIFF
--- a/Difficalcy/DifficalcyStartup.cs
+++ b/Difficalcy/DifficalcyStartup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using StackExchange.Redis;
 
@@ -29,6 +30,14 @@ namespace Difficalcy
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = OpenApiTitle, Version = OpenApiVersion });
+            });
+
+            services.AddLogging(options =>
+            {
+                options.AddSimpleConsole(console =>
+                {
+                    console.TimestampFormat = "[HH:mm:ss] ";
+                });
             });
 
             var redisConfig = Configuration["REDIS_CONFIGURATION"];

--- a/Difficalcy/Services/WebBeatmapProvider.cs
+++ b/Difficalcy/Services/WebBeatmapProvider.cs
@@ -2,10 +2,11 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace Difficalcy.Services
 {
-    public class WebBeatmapProvider(IConfiguration configuration) : IBeatmapProvider
+    public class WebBeatmapProvider(IConfiguration configuration, ILogger<WebBeatmapProvider> logger) : IBeatmapProvider
     {
         private readonly string _beatmapDirectory = configuration["BEATMAP_DIRECTORY"];
         private readonly string _downloadMissingBeatmaps = configuration["DOWNLOAD_MISSING_BEATMAPS"];
@@ -17,16 +18,25 @@ namespace Difficalcy.Services
             if (!File.Exists(beatmapPath))
             {
                 if (_downloadMissingBeatmaps != "true")
+                {
+                    logger.LogWarning("Beatmap {BeatmapId} not found and downloading is disabled", beatmapId);
                     throw new BeatmapNotFoundException(beatmapId);
+                }
+
+                logger.LogInformation("Downloading beatmap {BeatmapId}", beatmapId);
 
                 using var response = await _httpClient.GetAsync($"https://osu.ppy.sh/osu/{beatmapId}");
                 if (!response.IsSuccessStatusCode || response.Content.Headers.ContentLength == 0)
+                {
+                    logger.LogWarning("Failed to download beatmap {BeatmapId}", beatmapId);
                     throw new BeatmapNotFoundException(beatmapId);
+                }
 
                 using var fs = new FileStream(beatmapPath, FileMode.CreateNew);
                 await response.Content.CopyToAsync(fs);
                 if (fs.Length == 0)
                 {
+                    logger.LogWarning("Downloaded beatmap {BeatmapId} was empty, deleting", beatmapId);
                     fs.Close();
                     File.Delete(beatmapPath);
                     throw new BeatmapNotFoundException(beatmapId);


### PR DESCRIPTION
## Why?

We are occasionally getting missing beatmap errors and we don't have any logs to indicate why at the moment.

## Changes

- Add simple console logging configuration
- Add various logs for `WebBeatmapProvider`