### PR TITLE
Add release guardrail against uncommitted changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ endif
 ifneq "$(shell git branch --show-current)" "master"
 	$(error This command can only be run on the master branch)
 endif
+ifneq "$(shell git diff --name-only master)" ""
+	$(error There are uncommitted changes in the working directory)
+endif
 	echo $$GITHUB_PAT | docker login ghcr.io --username $$GITHUB_USERNAME --password-stdin
 	VERSION=$(VERSION) $(COMPOSE_PUBLISH) build
 	VERSION=$(VERSION) $(COMPOSE_PUBLISH) push difficalcy-osu difficalcy-taiko difficalcy-catch difficalcy-mania


### PR DESCRIPTION
## Why?

If there are uncommitted changes in the working directory, the released image would not match the version control.

## Changes

- Add uncommitted change check to `make release` command