### PR TITLE
Implement new mod format

### DIFF
--- a/Difficalcy.Catch.Tests/CatchCalculatorServiceTest.cs
+++ b/Difficalcy.Catch.Tests/CatchCalculatorServiceTest.cs
@@ -24,13 +24,20 @@ public class CatchCalculatorServiceTest : CalculatorServiceTest<CatchScore, Catc
             BeatmapId = "diffcalc-test",
             Mods = [
                 new Mod() { Acronym = "HR" },
-                new Mod() { Acronym = "DT" }
+                new Mod()
+                {
+                    Acronym = "DT",
+                    Settings = new Dictionary<string, string>
+                    {
+                        { "speed_change", "2" }
+                    }
+                }
             ],
             Combo = 100,
             Misses = 5,
             LargeDroplets = 18,
             SmallDroplets = 200,
         };
-        TestGetCalculationReturnsCorrectValues(5.739025024925009d, 241.19384779497875d, score);
+        TestGetCalculationReturnsCorrectValues(6.9017468199992278, 375.74458599075302, score);
     }
 }

--- a/Difficalcy.Catch.Tests/CatchCalculatorServiceTest.cs
+++ b/Difficalcy.Catch.Tests/CatchCalculatorServiceTest.cs
@@ -1,5 +1,6 @@
 using Difficalcy.Catch.Models;
 using Difficalcy.Catch.Services;
+using Difficalcy.Models;
 using Difficalcy.Services;
 using Difficalcy.Tests;
 
@@ -10,10 +11,10 @@ public class CatchCalculatorServiceTest : CalculatorServiceTest<CatchScore, Catc
     protected override CalculatorService<CatchScore, CatchDifficulty, CatchPerformance, CatchCalculation> CalculatorService { get; } = new CatchCalculatorService(new InMemoryCache(), new TestBeatmapProvider(typeof(CatchCalculatorService).Assembly.GetName().Name));
 
     [Theory]
-    [InlineData(4.0505463516206195d, 164.5770866821372d, "diffcalc-test", 0)]
-    [InlineData(5.1696411260785498d, 291.43480971713944d, "diffcalc-test", 64)]
-    public void Test(double expectedDifficultyTotal, double expectedPerformanceTotal, string beatmapId, int mods)
-        => TestGetCalculationReturnsCorrectValues(expectedDifficultyTotal, expectedPerformanceTotal, new CatchScore { BeatmapId = beatmapId, Mods = mods });
+    [InlineData(4.0505463516206195d, 164.5770866821372d, "diffcalc-test", new string[] { })]
+    [InlineData(5.1696411260785498d, 291.43480971713944d, "diffcalc-test", new string[] { "DT" })]
+    public void Test(double expectedDifficultyTotal, double expectedPerformanceTotal, string beatmapId, string[] mods)
+        => TestGetCalculationReturnsCorrectValues(expectedDifficultyTotal, expectedPerformanceTotal, new CatchScore { BeatmapId = beatmapId, Mods = mods.Select(m => new Mod { Acronym = m }).ToArray() });
 
     [Fact]
     public void TestAllParameters()
@@ -21,7 +22,10 @@ public class CatchCalculatorServiceTest : CalculatorServiceTest<CatchScore, Catc
         var score = new CatchScore
         {
             BeatmapId = "diffcalc-test",
-            Mods = 80, // HR, DT
+            Mods = [
+                new Mod() { Acronym = "HR" },
+                new Mod() { Acronym = "DT" }
+            ],
             Combo = 100,
             Misses = 5,
             LargeDroplets = 18,

--- a/Difficalcy.Mania.Tests/ManiaCalculatorServiceTest.cs
+++ b/Difficalcy.Mania.Tests/ManiaCalculatorServiceTest.cs
@@ -1,5 +1,6 @@
 using Difficalcy.Mania.Models;
 using Difficalcy.Mania.Services;
+using Difficalcy.Models;
 using Difficalcy.Services;
 using Difficalcy.Tests;
 
@@ -10,10 +11,10 @@ public class ManiaCalculatorServiceTest : CalculatorServiceTest<ManiaScore, Mani
     protected override CalculatorService<ManiaScore, ManiaDifficulty, ManiaPerformance, ManiaCalculation> CalculatorService { get; } = new ManiaCalculatorService(new InMemoryCache(), new TestBeatmapProvider(typeof(ManiaCalculatorService).Assembly.GetName().Name));
 
     [Theory]
-    [InlineData(2.3493769750220914d, 45.76140071089439d, "diffcalc-test", 0)]
-    [InlineData(2.797245912537965d, 68.79984443279172d, "diffcalc-test", 64)]
-    public void Test(double expectedDifficultyTotal, double expectedPerformanceTotal, string beatmapId, int mods)
-        => TestGetCalculationReturnsCorrectValues(expectedDifficultyTotal, expectedPerformanceTotal, new ManiaScore { BeatmapId = beatmapId, Mods = mods });
+    [InlineData(2.3493769750220914d, 45.76140071089439d, "diffcalc-test", new string[] { })]
+    [InlineData(2.797245912537965d, 68.79984443279172d, "diffcalc-test", new string[] { "DT" })]
+    public void Test(double expectedDifficultyTotal, double expectedPerformanceTotal, string beatmapId, string[] mods)
+        => TestGetCalculationReturnsCorrectValues(expectedDifficultyTotal, expectedPerformanceTotal, new ManiaScore { BeatmapId = beatmapId, Mods = mods.Select(m => new Mod { Acronym = m }).ToArray() });
 
     [Fact]
     public void TestAllParameters()
@@ -21,7 +22,9 @@ public class ManiaCalculatorServiceTest : CalculatorServiceTest<ManiaScore, Mani
         var score = new ManiaScore
         {
             BeatmapId = "diffcalc-test",
-            Mods = 64, // DT
+            Mods = [
+                new Mod() { Acronym = "DT" }
+            ],
             Misses = 5,
             Mehs = 4,
             Oks = 3,

--- a/Difficalcy.Mania.Tests/ManiaCalculatorServiceTest.cs
+++ b/Difficalcy.Mania.Tests/ManiaCalculatorServiceTest.cs
@@ -23,7 +23,14 @@ public class ManiaCalculatorServiceTest : CalculatorServiceTest<ManiaScore, Mani
         {
             BeatmapId = "diffcalc-test",
             Mods = [
-                new Mod() { Acronym = "DT" }
+                new Mod()
+                {
+                    Acronym = "DT",
+                    Settings = new Dictionary<string, string>
+                    {
+                        { "speed_change", "2" }
+                    }
+                }
             ],
             Misses = 5,
             Mehs = 4,
@@ -31,6 +38,6 @@ public class ManiaCalculatorServiceTest : CalculatorServiceTest<ManiaScore, Mani
             Goods = 2,
             Greats = 1,
         };
-        TestGetCalculationReturnsCorrectValues(2.797245912537965d, 43.17076331130473d, score);
+        TestGetCalculationReturnsCorrectValues(3.3252153148972425, 64.408516282383957, score);
     }
 }

--- a/Difficalcy.Osu.Tests/OsuCalculatorServiceTest.cs
+++ b/Difficalcy.Osu.Tests/OsuCalculatorServiceTest.cs
@@ -25,7 +25,14 @@ public class OsuCalculatorServiceTest : CalculatorServiceTest<OsuScore, OsuDiffi
             Mods = [
                 new Mod() { Acronym = "HD" },
                 new Mod() { Acronym = "HR" },
-                new Mod() { Acronym = "DT" },
+                new Mod()
+                {
+                    Acronym = "DT",
+                    Settings = new Dictionary<string, string>
+                    {
+                        { "speed_change", "2" }
+                    }
+                },
                 new Mod() { Acronym = "FL" }
             ],
             Combo = 200,
@@ -33,6 +40,19 @@ public class OsuCalculatorServiceTest : CalculatorServiceTest<OsuScore, OsuDiffi
             Mehs = 4,
             Oks = 3,
         };
-        TestGetCalculationReturnsCorrectValues(10.095171949076231d, 685.8314990408466d, score);
+        TestGetCalculationReturnsCorrectValues(12.418442356371395, 1415.202990027042, score);
+    }
+
+    [Fact]
+    public void TestClassicMod()
+    {
+        var score = new OsuScore
+        {
+            BeatmapId = "diffcalc-test",
+            Mods = [
+                new Mod() { Acronym = "CL" }
+            ],
+        };
+        TestGetCalculationReturnsCorrectValues(6.7171144000821119d, 289.16416504218972, score);
     }
 }

--- a/Difficalcy.Osu.Tests/OsuCalculatorServiceTest.cs
+++ b/Difficalcy.Osu.Tests/OsuCalculatorServiceTest.cs
@@ -1,3 +1,4 @@
+using Difficalcy.Models;
 using Difficalcy.Osu.Models;
 using Difficalcy.Osu.Services;
 using Difficalcy.Services;
@@ -10,10 +11,10 @@ public class OsuCalculatorServiceTest : CalculatorServiceTest<OsuScore, OsuDiffi
     protected override CalculatorService<OsuScore, OsuDifficulty, OsuPerformance, OsuCalculation> CalculatorService { get; } = new OsuCalculatorService(new InMemoryCache(), new TestBeatmapProvider(typeof(OsuCalculatorService).Assembly.GetName().Name));
 
     [Theory]
-    [InlineData(6.7171144000821119d, 291.34799376682508d, "diffcalc-test", 0)]
-    [InlineData(8.9825709931204205d, 717.13844713272601d, "diffcalc-test", 64)]
-    public void Test(double expectedDifficultyTotal, double expectedPerformanceTotal, string beatmapId, int mods)
-        => TestGetCalculationReturnsCorrectValues(expectedDifficultyTotal, expectedPerformanceTotal, new OsuScore { BeatmapId = beatmapId, Mods = mods });
+    [InlineData(6.7171144000821119d, 291.34799376682508d, "diffcalc-test", new string[] { })]
+    [InlineData(8.9825709931204205d, 717.13844713272601d, "diffcalc-test", new string[] { "DT" })]
+    public void Test(double expectedDifficultyTotal, double expectedPerformanceTotal, string beatmapId, string[] mods)
+        => TestGetCalculationReturnsCorrectValues(expectedDifficultyTotal, expectedPerformanceTotal, new OsuScore { BeatmapId = beatmapId, Mods = mods.Select(m => new Mod { Acronym = m }).ToArray() });
 
     [Fact]
     public void TestAllParameters()
@@ -21,7 +22,12 @@ public class OsuCalculatorServiceTest : CalculatorServiceTest<OsuScore, OsuDiffi
         var score = new OsuScore
         {
             BeatmapId = "diffcalc-test",
-            Mods = 1112, // HD, HR, DT, FL
+            Mods = [
+                new Mod() { Acronym = "HD" },
+                new Mod() { Acronym = "HR" },
+                new Mod() { Acronym = "DT" },
+                new Mod() { Acronym = "FL" }
+            ],
             Combo = 200,
             Misses = 5,
             Mehs = 4,

--- a/Difficalcy.Taiko.Tests/TaikoCalculatorServiceTest.cs
+++ b/Difficalcy.Taiko.Tests/TaikoCalculatorServiceTest.cs
@@ -2,6 +2,7 @@ using Difficalcy.Taiko.Models;
 using Difficalcy.Taiko.Services;
 using Difficalcy.Services;
 using Difficalcy.Tests;
+using Difficalcy.Models;
 
 namespace Difficalcy.Taiko.Tests;
 
@@ -10,10 +11,10 @@ public class TaikoCalculatorServiceTest : CalculatorServiceTest<TaikoScore, Taik
     protected override CalculatorService<TaikoScore, TaikoDifficulty, TaikoPerformance, TaikoCalculation> CalculatorService { get; } = new TaikoCalculatorService(new InMemoryCache(), new TestBeatmapProvider(typeof(TaikoCalculatorService).Assembly.GetName().Name));
 
     [Theory]
-    [InlineData(3.092021259435121d, 137.80325540434842d, "diffcalc-test", 0)]
-    [InlineData(4.0789820318081444d, 248.8310568362074d, "diffcalc-test", 64)]
-    public void Test(double expectedDifficultyTotal, double expectedPerformanceTotal, string beatmapId, int mods)
-        => TestGetCalculationReturnsCorrectValues(expectedDifficultyTotal, expectedPerformanceTotal, new TaikoScore { BeatmapId = beatmapId, Mods = mods });
+    [InlineData(3.092021259435121d, 137.80325540434842d, "diffcalc-test", new string[] { })]
+    [InlineData(4.0789820318081444d, 248.8310568362074d, "diffcalc-test", new string[] { "DT" })]
+    public void Test(double expectedDifficultyTotal, double expectedPerformanceTotal, string beatmapId, string[] mods)
+        => TestGetCalculationReturnsCorrectValues(expectedDifficultyTotal, expectedPerformanceTotal, new TaikoScore { BeatmapId = beatmapId, Mods = mods.Select(m => new Mod { Acronym = m }).ToArray() });
 
     [Fact]
     public void TestAllParameters()
@@ -21,7 +22,10 @@ public class TaikoCalculatorServiceTest : CalculatorServiceTest<TaikoScore, Taik
         var score = new TaikoScore
         {
             BeatmapId = "diffcalc-test",
-            Mods = 80, // HR, DT
+            Mods = [
+                new Mod() { Acronym = "HR" },
+                new Mod() { Acronym = "DT" }
+            ],
             Combo = 150,
             Misses = 5,
             Oks = 3,

--- a/Difficalcy.Taiko.Tests/TaikoCalculatorServiceTest.cs
+++ b/Difficalcy.Taiko.Tests/TaikoCalculatorServiceTest.cs
@@ -24,12 +24,19 @@ public class TaikoCalculatorServiceTest : CalculatorServiceTest<TaikoScore, Taik
             BeatmapId = "diffcalc-test",
             Mods = [
                 new Mod() { Acronym = "HR" },
-                new Mod() { Acronym = "DT" }
+                new Mod()
+                {
+                    Acronym = "DT",
+                    Settings = new Dictionary<string, string>
+                    {
+                        { "speed_change", "2" }
+                    }
+                }
             ],
             Combo = 150,
             Misses = 5,
             Oks = 3,
         };
-        TestGetCalculationReturnsCorrectValues(4.0789820318081444d, 240.24516772998618d, score);
+        TestGetCalculationReturnsCorrectValues(4.922364692298034, 359.95282202016443, score);
     }
 }

--- a/Difficalcy/Models/Score.cs
+++ b/Difficalcy/Models/Score.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 
 namespace Difficalcy.Models
 {
@@ -7,7 +9,24 @@ namespace Difficalcy.Models
         [Required]
         public string BeatmapId { get; init; }
 
-        [Range(0, int.MaxValue)]
-        public int Mods { get; init; } = 0;
+        public Mod[] Mods { get; init; } = [];
+    }
+
+    public record Mod
+    {
+        [Required]
+        public string Acronym { get; init; }
+
+        public Dictionary<string, string> Settings { get; init; } = [];
+
+        public override string ToString()
+        {
+            if (Settings.Count == 0)
+                return Acronym;
+
+            var settingsString = string.Join(",", Settings.OrderBy(setting => setting.Key).Select(setting => $"{setting.Key}={setting.Value}"));
+
+            return $"{Acronym}({settingsString})";
+        }
     }
 }

--- a/docs/docs/api-reference/difficalcy-catch.json
+++ b/docs/docs/api-reference/difficalcy-catch.json
@@ -82,10 +82,10 @@
             "name": "Mods",
             "in": "query",
             "schema": {
-              "maximum": 2147483647,
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32"
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Mod"
+              }
             }
           }
         ],
@@ -217,10 +217,11 @@
             "type": "string"
           },
           "mods": {
-            "maximum": 2147483647,
-            "minimum": 0,
-            "type": "integer",
-            "format": "int32"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Mod"
+            },
+            "nullable": true
           },
           "combo": {
             "maximum": 2147483647,
@@ -247,6 +248,27 @@
             "minimum": 0,
             "type": "integer",
             "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Mod": {
+        "required": [
+          "acronym"
+        ],
+        "type": "object",
+        "properties": {
+          "acronym": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "settings": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
             "nullable": true
           }
         },

--- a/docs/docs/api-reference/difficalcy-mania.json
+++ b/docs/docs/api-reference/difficalcy-mania.json
@@ -92,10 +92,10 @@
             "name": "Mods",
             "in": "query",
             "schema": {
-              "maximum": 2147483647,
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32"
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Mod"
+              }
             }
           }
         ],
@@ -227,10 +227,11 @@
             "type": "string"
           },
           "mods": {
-            "maximum": 2147483647,
-            "minimum": 0,
-            "type": "integer",
-            "format": "int32"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Mod"
+            },
+            "nullable": true
           },
           "misses": {
             "maximum": 2147483647,
@@ -261,6 +262,27 @@
             "minimum": 0,
             "type": "integer",
             "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Mod": {
+        "required": [
+          "acronym"
+        ],
+        "type": "object",
+        "properties": {
+          "acronym": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "settings": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/docs/docs/api-reference/difficalcy-osu.json
+++ b/docs/docs/api-reference/difficalcy-osu.json
@@ -82,10 +82,10 @@
             "name": "Mods",
             "in": "query",
             "schema": {
-              "maximum": 2147483647,
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32"
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Mod"
+              }
             }
           }
         ],
@@ -161,6 +161,27 @@
           },
           "calculatorUrl": {
             "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Mod": {
+        "required": [
+          "acronym"
+        ],
+        "type": "object",
+        "properties": {
+          "acronym": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "settings": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
             "nullable": true
           }
         },
@@ -245,10 +266,11 @@
             "type": "string"
           },
           "mods": {
-            "maximum": 2147483647,
-            "minimum": 0,
-            "type": "integer",
-            "format": "int32"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Mod"
+            },
+            "nullable": true
           },
           "combo": {
             "maximum": 2147483647,

--- a/docs/docs/api-reference/difficalcy-taiko.json
+++ b/docs/docs/api-reference/difficalcy-taiko.json
@@ -72,10 +72,10 @@
             "name": "Mods",
             "in": "query",
             "schema": {
-              "maximum": 2147483647,
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32"
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Mod"
+              }
             }
           }
         ],
@@ -156,6 +156,27 @@
         },
         "additionalProperties": false
       },
+      "Mod": {
+        "required": [
+          "acronym"
+        ],
+        "type": "object",
+        "properties": {
+          "acronym": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "settings": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "TaikoCalculation": {
         "type": "object",
         "properties": {
@@ -227,10 +248,11 @@
             "type": "string"
           },
           "mods": {
-            "maximum": 2147483647,
-            "minimum": 0,
-            "type": "integer",
-            "format": "int32"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Mod"
+            },
+            "nullable": true
           },
           "combo": {
             "maximum": 2147483647,


### PR DESCRIPTION
## Why?

Legacy mods don't support CL, mod settings, or any new lazer mods.
Even though we don't need mod settings or new lazer mods yet for osu!chan since they aren't ranked, we do need CL, so we might as well update anyway.

## Changes

- Implement new mod format using acronyms and settings k/v
- Update tests

## Breaking changes

- `mods` input parameter now a list of objects that specify the mod acronym and any optional settings
- eg. `POST /api/batch/calculation`

  ```json
  [
      {
          "beatmapId": "1256809",
          "mods": [
              {
                  "acronym": "DT",
                  "settings": {
                      "speed_change": "1.7"
                  }
              },
              {
                  "acronym": "CL"
              }
          ]
      }
  ]
  ```