### PR TITLE
Add /beatmapdetails endpoint

### DIFF
--- a/Difficalcy.Catch.Tests/CatchCalculatorServiceTest.cs
+++ b/Difficalcy.Catch.Tests/CatchCalculatorServiceTest.cs
@@ -7,13 +7,20 @@ using Difficalcy.Tests;
 namespace Difficalcy.Catch.Tests;
 
 public class CatchCalculatorServiceTest
-    : CalculatorServiceTest<CatchScore, CatchDifficulty, CatchPerformance, CatchCalculation>
+    : CalculatorServiceTest<
+        CatchScore,
+        CatchDifficulty,
+        CatchPerformance,
+        CatchCalculation,
+        CatchBeatmapDetails
+    >
 {
     protected override CalculatorService<
         CatchScore,
         CatchDifficulty,
         CatchPerformance,
-        CatchCalculation
+        CatchCalculation,
+        CatchBeatmapDetails
     > CalculatorService { get; } =
         new CatchCalculatorService(
             new InMemoryCache(),
@@ -60,5 +67,29 @@ public class CatchCalculatorServiceTest
             SmallDroplets = 200,
         };
         TestGetCalculationReturnsCorrectValues(6.61877502983358, 345.54834710808564, score);
+    }
+
+    [Fact]
+    public async Task TestBeatmapDetails()
+    {
+        var beatmapId = "diffcalc-test";
+        var beatmapDetails = await CalculatorService.GetBeatmapDetails(beatmapId);
+        Assert.Equal("Unknown", beatmapDetails.Artist);
+        Assert.Equal("Unknown", beatmapDetails.Title);
+        Assert.Equal("Normal", beatmapDetails.DifficultyName);
+        Assert.Equal("Unknown Creator", beatmapDetails.Author);
+        Assert.Equal(127, beatmapDetails.MaxCombo);
+        Assert.Equal(45250, beatmapDetails.Length);
+        Assert.Equal(120, beatmapDetails.MinBPM);
+        Assert.Equal(120, beatmapDetails.MaxBPM);
+        Assert.Equal(120, beatmapDetails.CommonBPM);
+        Assert.Equal(78, beatmapDetails.FruitCount);
+        Assert.Equal(12, beatmapDetails.JuiceStreamCount);
+        Assert.Equal(3, beatmapDetails.BananaShowerCount);
+        Assert.Equal(4, beatmapDetails.CircleSize);
+        Assert.Equal(8.3, beatmapDetails.ApproachRate, 4);
+        Assert.Equal(5, beatmapDetails.DrainRate);
+        Assert.Equal(1.6, beatmapDetails.BaseVelocity, 4);
+        Assert.Equal(1, beatmapDetails.TickRate);
     }
 }

--- a/Difficalcy.Catch/Controllers/CatchCalculatorController.cs
+++ b/Difficalcy.Catch/Controllers/CatchCalculatorController.cs
@@ -10,6 +10,7 @@ namespace Difficalcy.Catch.Controllers
             CatchDifficulty,
             CatchPerformance,
             CatchCalculation,
+            CatchBeatmapDetails,
             CatchCalculatorService
         >(calculatorService) { }
 }

--- a/Difficalcy.Catch/Models/CatchBeatmapDetails.cs
+++ b/Difficalcy.Catch/Models/CatchBeatmapDetails.cs
@@ -1,0 +1,17 @@
+using Difficalcy.Models;
+
+namespace Difficalcy.Catch.Models
+{
+    public record CatchBeatmapDetails : BeatmapDetails
+    {
+        // Hit Objects
+        public int FruitCount { get; init; }
+        public int JuiceStreamCount { get; init; }
+        public int BananaShowerCount { get; init; }
+
+        // Difficulty Settings
+        public double CircleSize { get; init; }
+        public double ApproachRate { get; init; }
+        public double DrainRate { get; init; }
+    }
+}

--- a/Difficalcy.Mania.Tests/ManiaCalculatorServiceTest.cs
+++ b/Difficalcy.Mania.Tests/ManiaCalculatorServiceTest.cs
@@ -7,13 +7,20 @@ using Difficalcy.Tests;
 namespace Difficalcy.Mania.Tests;
 
 public class ManiaCalculatorServiceTest
-    : CalculatorServiceTest<ManiaScore, ManiaDifficulty, ManiaPerformance, ManiaCalculation>
+    : CalculatorServiceTest<
+        ManiaScore,
+        ManiaDifficulty,
+        ManiaPerformance,
+        ManiaCalculation,
+        ManiaBeatmapDetails
+    >
 {
     protected override CalculatorService<
         ManiaScore,
         ManiaDifficulty,
         ManiaPerformance,
-        ManiaCalculation
+        ManiaCalculation,
+        ManiaBeatmapDetails
     > CalculatorService { get; } =
         new ManiaCalculatorService(
             new InMemoryCache(),
@@ -60,5 +67,28 @@ public class ManiaCalculatorServiceTest
             Greats = 1,
         };
         TestGetCalculationReturnsCorrectValues(3.3252153148972425, 64.40851628238396, score);
+    }
+
+    [Fact]
+    public async Task TestBeatmapDetails()
+    {
+        var beatmapId = "diffcalc-test";
+        var beatmapDetails = await CalculatorService.GetBeatmapDetails(beatmapId);
+        Assert.Equal("Unknown", beatmapDetails.Artist);
+        Assert.Equal("Unknown", beatmapDetails.Title);
+        Assert.Equal("Normal", beatmapDetails.DifficultyName);
+        Assert.Equal("Unknown Creator", beatmapDetails.Author);
+        Assert.Equal(151, beatmapDetails.MaxCombo);
+        Assert.Equal(30500, beatmapDetails.Length);
+        Assert.Equal(120, beatmapDetails.MinBPM);
+        Assert.Equal(120, beatmapDetails.MaxBPM);
+        Assert.Equal(120, beatmapDetails.CommonBPM);
+        Assert.Equal(123, beatmapDetails.NoteCount);
+        Assert.Equal(14, beatmapDetails.HoldNoteCount);
+        Assert.Equal(4, beatmapDetails.KeyCount);
+        Assert.Equal(7, beatmapDetails.Accuracy);
+        Assert.Equal(5, beatmapDetails.DrainRate);
+        Assert.Equal(1.6, beatmapDetails.BaseVelocity, 4);
+        Assert.Equal(1, beatmapDetails.TickRate);
     }
 }

--- a/Difficalcy.Mania/Controllers/ManiaCalculatorController.cs
+++ b/Difficalcy.Mania/Controllers/ManiaCalculatorController.cs
@@ -10,6 +10,7 @@ namespace Difficalcy.Mania.Controllers
             ManiaDifficulty,
             ManiaPerformance,
             ManiaCalculation,
+            ManiaBeatmapDetails,
             ManiaCalculatorService
         >(calculatorService) { }
 }

--- a/Difficalcy.Mania/Models/ManiaBeatmapDetails.cs
+++ b/Difficalcy.Mania/Models/ManiaBeatmapDetails.cs
@@ -1,0 +1,16 @@
+using Difficalcy.Models;
+
+namespace Difficalcy.Mania.Models
+{
+    public record ManiaBeatmapDetails : BeatmapDetails
+    {
+        // Hit Objects
+        public int NoteCount { get; init; }
+        public int HoldNoteCount { get; init; }
+
+        // Difficulty Settings
+        public double KeyCount { get; init; }
+        public double Accuracy { get; init; }
+        public double DrainRate { get; init; }
+    }
+}

--- a/Difficalcy.Osu.Tests/OsuCalculatorServiceTest.cs
+++ b/Difficalcy.Osu.Tests/OsuCalculatorServiceTest.cs
@@ -7,13 +7,20 @@ using Difficalcy.Tests;
 namespace Difficalcy.Osu.Tests;
 
 public class OsuCalculatorServiceTest
-    : CalculatorServiceTest<OsuScore, OsuDifficulty, OsuPerformance, OsuCalculation>
+    : CalculatorServiceTest<
+        OsuScore,
+        OsuDifficulty,
+        OsuPerformance,
+        OsuCalculation,
+        OsuBeatmapDetails
+    >
 {
     protected override CalculatorService<
         OsuScore,
         OsuDifficulty,
         OsuPerformance,
-        OsuCalculation
+        OsuCalculation,
+        OsuBeatmapDetails
     > CalculatorService { get; } =
         new OsuCalculatorService(
             new InMemoryCache(),
@@ -92,5 +99,31 @@ public class OsuCalculatorServiceTest
             SliderTicks = 1,
         };
         TestGetCalculationReturnsCorrectValues(13.89060549007635, 2012.0980668102025, score);
+    }
+
+    [Fact]
+    public async Task TestGetBeatmapDetails()
+    {
+        var beatmapId = "diffcalc-test";
+        var beatmapDetails = await CalculatorService.GetBeatmapDetails(beatmapId);
+        Assert.Equal("Unknown", beatmapDetails.Artist);
+        Assert.Equal("Unknown", beatmapDetails.Title);
+        Assert.Equal("Normal", beatmapDetails.DifficultyName);
+        Assert.Equal("Unknown Creator", beatmapDetails.Author);
+        Assert.Equal(239, beatmapDetails.MaxCombo);
+        Assert.Equal(102500, beatmapDetails.Length);
+        Assert.Equal(120, beatmapDetails.MinBPM);
+        Assert.Equal(120, beatmapDetails.MaxBPM);
+        Assert.Equal(120, beatmapDetails.CommonBPM);
+        Assert.Equal(79, beatmapDetails.CircleCount);
+        Assert.Equal(33, beatmapDetails.SliderCount);
+        Assert.Equal(12, beatmapDetails.SpinnerCount);
+        Assert.Equal(82, beatmapDetails.SliderTickCount);
+        Assert.Equal(4, beatmapDetails.CircleSize);
+        Assert.Equal(8.3, beatmapDetails.ApproachRate, 4);
+        Assert.Equal(7, beatmapDetails.Accuracy);
+        Assert.Equal(5, beatmapDetails.DrainRate);
+        Assert.Equal(1.6, beatmapDetails.BaseVelocity, 4);
+        Assert.Equal(1, beatmapDetails.TickRate);
     }
 }

--- a/Difficalcy.Osu/Controllers/OsuCalculatorController.cs
+++ b/Difficalcy.Osu/Controllers/OsuCalculatorController.cs
@@ -10,6 +10,7 @@ namespace Difficalcy.Osu.Controllers
             OsuDifficulty,
             OsuPerformance,
             OsuCalculation,
+            OsuBeatmapDetails,
             OsuCalculatorService
         >(calculatorService) { }
 }

--- a/Difficalcy.Osu/Models/OsuBeatmapDetails.cs
+++ b/Difficalcy.Osu/Models/OsuBeatmapDetails.cs
@@ -1,0 +1,19 @@
+using Difficalcy.Models;
+
+namespace Difficalcy.Osu.Models
+{
+    public record OsuBeatmapDetails : BeatmapDetails
+    {
+        // Hit Objects
+        public int CircleCount { get; init; }
+        public int SliderCount { get; init; }
+        public int SpinnerCount { get; init; }
+        public int SliderTickCount { get; init; }
+
+        // Difficulty Settings
+        public double CircleSize { get; init; }
+        public double ApproachRate { get; init; }
+        public double Accuracy { get; init; }
+        public double DrainRate { get; init; }
+    }
+}

--- a/Difficalcy.Taiko.Tests/TaikoCalculatorServiceTest.cs
+++ b/Difficalcy.Taiko.Tests/TaikoCalculatorServiceTest.cs
@@ -7,13 +7,20 @@ using Difficalcy.Tests;
 namespace Difficalcy.Taiko.Tests;
 
 public class TaikoCalculatorServiceTest
-    : CalculatorServiceTest<TaikoScore, TaikoDifficulty, TaikoPerformance, TaikoCalculation>
+    : CalculatorServiceTest<
+        TaikoScore,
+        TaikoDifficulty,
+        TaikoPerformance,
+        TaikoCalculation,
+        TaikoBeatmapDetails
+    >
 {
     protected override CalculatorService<
         TaikoScore,
         TaikoDifficulty,
         TaikoPerformance,
-        TaikoCalculation
+        TaikoCalculation,
+        TaikoBeatmapDetails
     > CalculatorService { get; } =
         new TaikoCalculatorService(
             new InMemoryCache(),
@@ -59,5 +66,28 @@ public class TaikoCalculatorServiceTest
             Oks = 3,
         };
         TestGetCalculationReturnsCorrectValues(6.216091072305756, 451.45173560370836, score);
+    }
+
+    [Fact]
+    public async Task TestBeatmapDetails()
+    {
+        var beatmapId = "diffcalc-test";
+        var beatmapDetails = await CalculatorService.GetBeatmapDetails(beatmapId);
+        Assert.Equal("Unknown", beatmapDetails.Artist);
+        Assert.Equal("Unknown", beatmapDetails.Title);
+        Assert.Equal("Normal", beatmapDetails.DifficultyName);
+        Assert.Equal("Unknown Creator", beatmapDetails.Author);
+        Assert.Equal(200, beatmapDetails.MaxCombo);
+        Assert.Equal(53000, beatmapDetails.Length);
+        Assert.Equal(120, beatmapDetails.MinBPM);
+        Assert.Equal(120, beatmapDetails.MaxBPM);
+        Assert.Equal(120, beatmapDetails.CommonBPM);
+        Assert.Equal(200, beatmapDetails.HitCount);
+        Assert.Equal(30, beatmapDetails.DrumRollCount);
+        Assert.Equal(8, beatmapDetails.SwellCount);
+        Assert.Equal(7, beatmapDetails.Accuracy);
+        Assert.Equal(5, beatmapDetails.DrainRate);
+        Assert.Equal(1.6, beatmapDetails.BaseVelocity, 4);
+        Assert.Equal(1, beatmapDetails.TickRate);
     }
 }

--- a/Difficalcy.Taiko/Controllers/TaikoCalculatorController.cs
+++ b/Difficalcy.Taiko/Controllers/TaikoCalculatorController.cs
@@ -10,6 +10,7 @@ namespace Difficalcy.Taiko.Controllers
             TaikoDifficulty,
             TaikoPerformance,
             TaikoCalculation,
+            TaikoBeatmapDetails,
             TaikoCalculatorService
         >(calculatorService) { }
 }

--- a/Difficalcy.Taiko/Models/TaikoBeatmapDetails.cs
+++ b/Difficalcy.Taiko/Models/TaikoBeatmapDetails.cs
@@ -1,0 +1,16 @@
+using Difficalcy.Models;
+
+namespace Difficalcy.Taiko.Models
+{
+    public record TaikoBeatmapDetails : BeatmapDetails
+    {
+        // Hit Objects
+        public int HitCount { get; init; }
+        public int DrumRollCount { get; init; }
+        public int SwellCount { get; init; }
+
+        // Difficulty Settings
+        public double Accuracy { get; init; }
+        public double DrainRate { get; init; }
+    }
+}

--- a/Difficalcy.Tests/CalculatorServiceTest.cs
+++ b/Difficalcy.Tests/CalculatorServiceTest.cs
@@ -3,17 +3,25 @@ namespace Difficalcy.Tests;
 using Difficalcy.Models;
 using Difficalcy.Services;
 
-public abstract class CalculatorServiceTest<TScore, TDifficulty, TPerformance, TCalculation>
+public abstract class CalculatorServiceTest<
+    TScore,
+    TDifficulty,
+    TPerformance,
+    TCalculation,
+    TBeatmapDetails
+>
     where TScore : Score
     where TDifficulty : Difficulty
     where TPerformance : Performance
     where TCalculation : Calculation<TDifficulty, TPerformance>
+    where TBeatmapDetails : BeatmapDetails
 {
     protected abstract CalculatorService<
         TScore,
         TDifficulty,
         TPerformance,
-        TCalculation
+        TCalculation,
+        TBeatmapDetails
     > CalculatorService { get; }
 
     public async void TestGetCalculationReturnsCorrectValues(

--- a/Difficalcy.Tests/DummyCalculatorServiceTest.cs
+++ b/Difficalcy.Tests/DummyCalculatorServiceTest.cs
@@ -1,16 +1,24 @@
 namespace Difficalcy.Tests;
 
+using System.Threading.Tasks;
 using Difficalcy.Models;
 using Difficalcy.Services;
 
 public class DummyCalculatorServiceTest
-    : CalculatorServiceTest<DummyScore, DummyDifficulty, DummyPerformance, DummyCalculation>
+    : CalculatorServiceTest<
+        DummyScore,
+        DummyDifficulty,
+        DummyPerformance,
+        DummyCalculation,
+        DummyBeatmapDetails
+    >
 {
     protected override CalculatorService<
         DummyScore,
         DummyDifficulty,
         DummyPerformance,
-        DummyCalculation
+        DummyCalculation,
+        DummyBeatmapDetails
     > CalculatorService { get; } = new DummyCalculatorService(new InMemoryCache());
 
     [Theory]
@@ -153,13 +161,38 @@ public class DummyCalculatorServiceTest
         Assert.Equal(10, calculations[11].Difficulty.Total); // 0
         Assert.Equal(1000, calculations[11].Performance.Total);
     }
+
+    [Fact]
+    public async Task TestGetBeatmapDetailsReturnsCorrectValues()
+    {
+        var beatmapId = "test 1";
+        var beatmapDetails = await CalculatorService.GetBeatmapDetails(beatmapId);
+
+        Assert.Equal("Dummy artist", beatmapDetails.Artist);
+        Assert.Equal("Dummy title", beatmapDetails.Title);
+        Assert.Equal("Dummy diff", beatmapDetails.DifficultyName);
+        Assert.Equal("Dummy author", beatmapDetails.Author);
+        Assert.Equal(100, beatmapDetails.MaxCombo);
+        Assert.Equal(200, beatmapDetails.Length);
+        Assert.Equal(300, beatmapDetails.MinBPM);
+        Assert.Equal(400, beatmapDetails.MaxBPM);
+        Assert.Equal(500, beatmapDetails.CommonBPM);
+        Assert.Equal(600, beatmapDetails.BaseVelocity);
+        Assert.Equal(700, beatmapDetails.TickRate);
+    }
 }
 
 /// <summary>
 /// A dummy calculator service implementation that calculates difficulty as mods (casted from string to double) / 10 and performance as difficulty * points
 /// </summary>
 public class DummyCalculatorService(ICache cache)
-    : CalculatorService<DummyScore, DummyDifficulty, DummyPerformance, DummyCalculation>(cache)
+    : CalculatorService<
+        DummyScore,
+        DummyDifficulty,
+        DummyPerformance,
+        DummyCalculation,
+        DummyBeatmapDetails
+    >(cache)
 {
     public override CalculatorInfo Info =>
         new()
@@ -170,6 +203,24 @@ public class DummyCalculatorService(ICache cache)
             CalculatorVersion = "DummyCalculatorVersion",
             CalculatorUrl = $"not.a.real.url",
         };
+
+    protected override DummyBeatmapDetails GetBeatmapDetailsSync(string beatmapId)
+    {
+        return new DummyBeatmapDetails
+        {
+            Artist = "Dummy artist",
+            Title = "Dummy title",
+            DifficultyName = "Dummy diff",
+            Author = "Dummy author",
+            MaxCombo = 100,
+            Length = 200,
+            MinBPM = 300,
+            MaxBPM = 400,
+            CommonBPM = 500,
+            BaseVelocity = 600,
+            TickRate = 700,
+        };
+    }
 
     protected override (object, string) CalculateDifficultyAttributes(string beatmapId, Mod[] mods)
     {
@@ -206,3 +257,5 @@ public record DummyDifficulty : Difficulty { }
 public record DummyPerformance : Performance { }
 
 public record DummyCalculation : Calculation<DummyDifficulty, DummyPerformance> { }
+
+public record DummyBeatmapDetails : BeatmapDetails { }

--- a/Difficalcy/Controllers/CalculatorController.cs
+++ b/Difficalcy/Controllers/CalculatorController.cs
@@ -13,17 +13,20 @@ namespace Difficalcy.Controllers
         TDifficulty,
         TPerformance,
         TCalculation,
+        TBeatmapDetails,
         TCalculatorService
     >(TCalculatorService calculatorService) : ControllerBase
         where TScore : Score
         where TDifficulty : Difficulty
         where TPerformance : Performance
         where TCalculation : Calculation<TDifficulty, TPerformance>
+        where TBeatmapDetails : BeatmapDetails
         where TCalculatorService : CalculatorService<
                 TScore,
                 TDifficulty,
                 TPerformance,
-                TCalculation
+                TCalculation,
+                TBeatmapDetails
             >
     {
         protected readonly TCalculatorService calculatorService = calculatorService;
@@ -35,6 +38,24 @@ namespace Difficalcy.Controllers
         public ActionResult<CalculatorInfo> GetInfo()
         {
             return Ok(calculatorService.Info);
+        }
+
+        /// <summary>
+        /// Returns beatmap details.
+        /// </summary>
+        [HttpGet("beatmapdetails")]
+        public async Task<ActionResult<TBeatmapDetails>> GetBeatmapDetails(
+            [FromQuery] string beatmapId
+        )
+        {
+            try
+            {
+                return Ok(await calculatorService.GetBeatmapDetails(beatmapId));
+            }
+            catch (BeatmapNotFoundException e)
+            {
+                return BadRequest(new { error = e.Message });
+            }
         }
 
         /// <summary>

--- a/Difficalcy/Models/BeatmapDetails.cs
+++ b/Difficalcy/Models/BeatmapDetails.cs
@@ -1,0 +1,20 @@
+namespace Difficalcy.Models
+{
+    public abstract record BeatmapDetails
+    {
+        // Metadata
+        public string Artist { get; init; }
+        public string Title { get; init; }
+        public string DifficultyName { get; init; }
+        public string Author { get; init; }
+
+        // Statistics
+        public int MaxCombo { get; init; }
+        public double Length { get; init; }
+        public int MinBPM { get; init; }
+        public int MaxBPM { get; init; }
+        public int CommonBPM { get; init; }
+        public double BaseVelocity { get; init; }
+        public double TickRate { get; init; }
+    }
+}

--- a/Difficalcy/Services/CalculatorService.cs
+++ b/Difficalcy/Services/CalculatorService.cs
@@ -5,13 +5,18 @@ using Difficalcy.Models;
 
 namespace Difficalcy.Services
 {
-    public abstract class CalculatorService<TScore, TDifficulty, TPerformance, TCalculation>(
-        ICache cache
-    )
+    public abstract class CalculatorService<
+        TScore,
+        TDifficulty,
+        TPerformance,
+        TCalculation,
+        TBeatmapDetails
+    >(ICache cache)
         where TScore : Score
         where TDifficulty : Difficulty
         where TPerformance : Performance
         where TCalculation : Calculation<TDifficulty, TPerformance>
+        where TBeatmapDetails : BeatmapDetails
     {
         /// <summary>
         /// A set of information describing the calculator.
@@ -50,6 +55,17 @@ namespace Difficalcy.Services
             TScore score,
             object difficultyAttributes
         );
+
+        /// <summary>
+        /// Returns the beatmap details for a given beatmap ID.
+        /// </summary>
+        public async Task<TBeatmapDetails> GetBeatmapDetails(string beatmapId)
+        {
+            await EnsureBeatmap(beatmapId);
+            return GetBeatmapDetailsSync(beatmapId);
+        }
+
+        protected abstract TBeatmapDetails GetBeatmapDetailsSync(string beatmapId);
 
         /// <summary>
         /// Returns the calculation of a given score.

--- a/docs/docs/api-reference/difficalcy-catch.json
+++ b/docs/docs/api-reference/difficalcy-catch.json
@@ -24,6 +24,34 @@
         }
       }
     },
+    "/api/beatmapdetails": {
+      "get": {
+        "tags": [
+          "CatchCalculator"
+        ],
+        "parameters": [
+          {
+            "name": "beatmapId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatchBeatmapDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/calculation": {
       "get": {
         "tags": [
@@ -162,6 +190,80 @@
           "calculatorUrl": {
             "type": "string",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CatchBeatmapDetails": {
+        "type": "object",
+        "properties": {
+          "artist": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "difficultyName": {
+            "type": "string",
+            "nullable": true
+          },
+          "author": {
+            "type": "string",
+            "nullable": true
+          },
+          "maxCombo": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "length": {
+            "type": "number",
+            "format": "double"
+          },
+          "minBPM": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxBPM": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "commonBPM": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "baseVelocity": {
+            "type": "number",
+            "format": "double"
+          },
+          "tickRate": {
+            "type": "number",
+            "format": "double"
+          },
+          "fruitCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "juiceStreamCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "bananaShowerCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "circleSize": {
+            "type": "number",
+            "format": "double"
+          },
+          "approachRate": {
+            "type": "number",
+            "format": "double"
+          },
+          "drainRate": {
+            "type": "number",
+            "format": "double"
           }
         },
         "additionalProperties": false

--- a/docs/docs/api-reference/difficalcy-mania.json
+++ b/docs/docs/api-reference/difficalcy-mania.json
@@ -24,6 +24,34 @@
         }
       }
     },
+    "/api/beatmapdetails": {
+      "get": {
+        "tags": [
+          "ManiaCalculator"
+        ],
+        "parameters": [
+          {
+            "name": "beatmapId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManiaBeatmapDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/calculation": {
       "get": {
         "tags": [
@@ -172,6 +200,76 @@
           "calculatorUrl": {
             "type": "string",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ManiaBeatmapDetails": {
+        "type": "object",
+        "properties": {
+          "artist": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "difficultyName": {
+            "type": "string",
+            "nullable": true
+          },
+          "author": {
+            "type": "string",
+            "nullable": true
+          },
+          "maxCombo": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "length": {
+            "type": "number",
+            "format": "double"
+          },
+          "minBPM": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxBPM": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "commonBPM": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "baseVelocity": {
+            "type": "number",
+            "format": "double"
+          },
+          "tickRate": {
+            "type": "number",
+            "format": "double"
+          },
+          "noteCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "holdNoteCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "keyCount": {
+            "type": "number",
+            "format": "double"
+          },
+          "accuracy": {
+            "type": "number",
+            "format": "double"
+          },
+          "drainRate": {
+            "type": "number",
+            "format": "double"
           }
         },
         "additionalProperties": false

--- a/docs/docs/api-reference/difficalcy-osu.json
+++ b/docs/docs/api-reference/difficalcy-osu.json
@@ -24,6 +24,34 @@
         }
       }
     },
+    "/api/beatmapdetails": {
+      "get": {
+        "tags": [
+          "OsuCalculator"
+        ],
+        "parameters": [
+          {
+            "name": "beatmapId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OsuBeatmapDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/calculation": {
       "get": {
         "tags": [
@@ -203,6 +231,88 @@
               "nullable": true
             },
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "OsuBeatmapDetails": {
+        "type": "object",
+        "properties": {
+          "artist": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "difficultyName": {
+            "type": "string",
+            "nullable": true
+          },
+          "author": {
+            "type": "string",
+            "nullable": true
+          },
+          "maxCombo": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "length": {
+            "type": "number",
+            "format": "double"
+          },
+          "minBPM": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxBPM": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "commonBPM": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "baseVelocity": {
+            "type": "number",
+            "format": "double"
+          },
+          "tickRate": {
+            "type": "number",
+            "format": "double"
+          },
+          "circleCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sliderCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "spinnerCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sliderTickCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "circleSize": {
+            "type": "number",
+            "format": "double"
+          },
+          "approachRate": {
+            "type": "number",
+            "format": "double"
+          },
+          "accuracy": {
+            "type": "number",
+            "format": "double"
+          },
+          "drainRate": {
+            "type": "number",
+            "format": "double"
           }
         },
         "additionalProperties": false

--- a/docs/docs/api-reference/difficalcy-taiko.json
+++ b/docs/docs/api-reference/difficalcy-taiko.json
@@ -24,6 +24,34 @@
         }
       }
     },
+    "/api/beatmapdetails": {
+      "get": {
+        "tags": [
+          "TaikoCalculator"
+        ],
+        "parameters": [
+          {
+            "name": "beatmapId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaikoBeatmapDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/calculation": {
       "get": {
         "tags": [
@@ -173,6 +201,76 @@
               "nullable": true
             },
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TaikoBeatmapDetails": {
+        "type": "object",
+        "properties": {
+          "artist": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "difficultyName": {
+            "type": "string",
+            "nullable": true
+          },
+          "author": {
+            "type": "string",
+            "nullable": true
+          },
+          "maxCombo": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "length": {
+            "type": "number",
+            "format": "double"
+          },
+          "minBPM": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxBPM": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "commonBPM": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "baseVelocity": {
+            "type": "number",
+            "format": "double"
+          },
+          "tickRate": {
+            "type": "number",
+            "format": "double"
+          },
+          "hitCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "drumRollCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "swellCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "accuracy": {
+            "type": "number",
+            "format": "double"
+          },
+          "drainRate": {
+            "type": "number",
+            "format": "double"
           }
         },
         "additionalProperties": false

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -257,6 +257,36 @@ curl "localhost:5000/api/batch/calculation" \
 ]
 ```
 
+There is also a `/beatmapdetails` endpoint for getting various specifics about a beatmap:
+
+```sh
+$ curl "localhost:5000/api/beatmapdetails?BeatmapId=658127"
+```
+
+```json
+{
+  "circleCount": 1760,
+  "sliderCount": 210,
+  "spinnerCount": 3,
+  "sliderTickCount": 219,
+  "circleSize": 4,
+  "approachRate": 9.6,
+  "accuracy": 9,
+  "drainRate": 6,
+  "artist": "xi",
+  "title": "Blue Zenith",
+  "difficultyName": "FOUR DIMENSIONS",
+  "author": "Asphyxia",
+  "maxCombo": 2402,
+  "length": 250800,
+  "minBPM": 200,
+  "maxBPM": 200,
+  "commonBPM": 200,
+  "baseVelocity": 1.8,
+  "tickRate": 1
+}
+```
+
 ## Recommended setup
 
 In a real deployment, caching is important, so including a redis instance and persistent volumes for both beatmaps and redis data will help you a lot.


### PR DESCRIPTION
## Why?

In osuchan, it's become necessary to get beatmap details that aren't easily available via the API (eg. slider ticks and slider ends to new lazer calculate accuracy).
Difficalcy is a natural service to house this sort of beatmap details endpoint as it already works with the data.

## Changes

- Add `/beatmapdetails` endpoint