### PR TITLE
Add create-new-release workflow

### DIFF
--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -1,0 +1,16 @@
+name: create-new-release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release"
+        required: true
+        default: "v0.0.0"
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: make release GITHUB_USERNAME=${{ github.actor }} GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} VERSION=${{ github.event.inputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ release:	## Pushes docker images to ghcr.io and create a github release
 ifndef VERSION
 	$(error VERSION is undefined)
 endif
-ifndef GITHUB_PAT
-	$(error GITHUB_PAT env var is not set)
+ifndef GITHUB_TOKEN
+	$(error GITHUB_TOKEN env var is not set)
 endif
 ifndef GITHUB_USERNAME
 	$(error GITHUB_USERNAME env var is not set)
@@ -63,7 +63,7 @@ endif
 ifneq "$(shell git diff --name-only master)" ""
 	$(error There are uncommitted changes in the working directory)
 endif
-	echo $$GITHUB_PAT | docker login ghcr.io --username $$GITHUB_USERNAME --password-stdin
+	echo $$GITHUB_TOKEN | docker login ghcr.io --username $$GITHUB_USERNAME --password-stdin
 	VERSION=$(VERSION) $(COMPOSE_PUBLISH) build
 	VERSION=$(VERSION) $(COMPOSE_PUBLISH) push difficalcy-osu difficalcy-taiko difficalcy-catch difficalcy-mania
 	VERSION=latest $(COMPOSE_PUBLISH) build


### PR DESCRIPTION
## Why?

Pushing to ghcr from my local machine is so slow!

## Changes

- Add `create-new-release` workflow