### PR TITLE
Use env in workflow for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -16,4 +16,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - run: make release GITHUB_USERNAME=${{ github.actor }} GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} VERSION=${{ github.event.inputs.version }}
+      - run: make release VERSION=${{ github.event.inputs.version }} GITHUB_USERNAME=${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why?

Probably a better practice for `GITHUB_TOKEN`