### PR TITLE
Remove unnecessary envvars from e2e compose

### DIFF
--- a/compose.override.e2e.yaml
+++ b/compose.override.e2e.yaml
@@ -20,7 +20,6 @@ services:
   difficalcy-osu:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
-      - BEATMAP_DIRECTORY=/beatmaps
       - BEATMAP_DOWNLOAD_URL=http://beatmap-server:80/{beatmapId}.osu
     depends_on:
       - beatmap-server
@@ -28,7 +27,6 @@ services:
   difficalcy-taiko:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
-      - BEATMAP_DIRECTORY=/beatmaps
       - BEATMAP_DOWNLOAD_URL=http://beatmap-server:80/{beatmapId}.osu
     depends_on:
       - beatmap-server
@@ -36,7 +34,6 @@ services:
   difficalcy-catch:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
-      - BEATMAP_DIRECTORY=/beatmaps
       - BEATMAP_DOWNLOAD_URL=http://beatmap-server:80/{beatmapId}.osu
     depends_on:
       - beatmap-server
@@ -44,7 +41,6 @@ services:
   difficalcy-mania:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
-      - BEATMAP_DIRECTORY=/beatmaps
       - BEATMAP_DOWNLOAD_URL=http://beatmap-server:80/{beatmapId}.osu
     depends_on:
       - beatmap-server


### PR DESCRIPTION
## Why?

Oopsie

## Changes

- Remove unnecessary env vars (duplicate of default)
