### PR TITLE
Add pre-release support

### DIFF
--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -5,8 +5,13 @@ on:
       version:
         description: "Version to release"
         required: true
-        default: "v0.0.0"
+        default: "v0.0.0-alpha.0"
         type: string
+      prerelease:
+        description: "Create as pre-release"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   release:
@@ -16,6 +21,13 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - run: make release VERSION=${{ github.event.inputs.version }} GITHUB_USERNAME=${{ github.actor }}
+      - name: Release
+        if: ${{ !inputs.prerelease }}
+        run: make release VERSION=${{ inputs.version }} GITHUB_USERNAME=${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pre-release
+        if: ${{ inputs.prerelease }}
+        run: make pre-release VERSION=${{ inputs.version }} GITHUB_USERNAME=${{ github.actor }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,22 @@ endif
 	VERSION=latest $(COMPOSE_PUBLISH) build
 	VERSION=latest $(COMPOSE_PUBLISH) push difficalcy
 	gh release create "$(VERSION)" --generate-notes
+
+VERSION =
+pre-release:	## Pushes docker image to ghcr.io and create a github prerelease
+ifndef VERSION
+	$(error VERSION is undefined)
+endif
+ifndef GITHUB_TOKEN
+	$(error GITHUB_TOKEN env var is not set)
+endif
+ifndef GITHUB_USERNAME
+	$(error GITHUB_USERNAME env var is not set)
+endif
+ifneq "$(shell git diff --name-only HEAD)" ""
+	$(error There are uncommitted changes in the working directory)
+endif
+	echo $$GITHUB_TOKEN | docker login ghcr.io --username $$GITHUB_USERNAME --password-stdin
+	VERSION=$(VERSION) $(COMPOSE_PUBLISH) build
+	VERSION=$(VERSION) $(COMPOSE_PUBLISH) push difficalcy
+	gh release create "$(VERSION)" --generate-notes --prerelease


### PR DESCRIPTION
## Why?

I want to test drive v1 as an alpha for a while before committing to the new API, so we need to be able to publish it as a pre-release.

## Changes

- Add pre-release support to create-new-release workflow
