### PR TITLE
Trim image down and publish slim variant

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,6 @@
 **/npm-debug.log
 **/obj
 **/secrets.dev.yaml
-**/tools
+**/tools/StripResources/{bin,obj}
 **/values.dev.yaml
 README.md

--- a/.gitignore
+++ b/.gitignore
@@ -265,7 +265,7 @@ __pycache__/
 *.pyc
 
 # Cake - Uncomment if you are using it
-tools/
+# tools/
 
 .vscode/
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <Target
+    Name="RemoveSatelliteAssemblies"
+    AfterTargets="_ComputeIlcCompileInputs"
+    BeforeTargets="WriteIlcRspFileForCompilation"
+  >
+    <ItemGroup>
+      <IlcSatelliteAssembly Remove="@(IlcSatelliteAssembly)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ VOLUME ${BEATMAP_DIRECTORY}
 
 USER app
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+# -----------------------------------------------------------------------------
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-base
 WORKDIR /src
 
 COPY ./Directory.Build.props ./
@@ -22,6 +24,7 @@ COPY ./Directory.Build.props ./
 # AOT compilation dependencies
 RUN apt-get update && apt-get install -y clang zlib1g-dev && rm -rf /var/lib/apt/lists/*
 
+# Restore main project
 COPY ./Difficalcy/Difficalcy.csproj ./Difficalcy/
 COPY ./Difficalcy.Api/Difficalcy.Api.csproj ./Difficalcy.Api/
 COPY ./Difficalcy.Osu/Difficalcy.Osu.csproj ./Difficalcy.Osu/
@@ -31,6 +34,7 @@ COPY ./Difficalcy.Mania/Difficalcy.Mania.csproj ./Difficalcy.Mania/
 
 RUN dotnet restore ./Difficalcy.Api/Difficalcy.Api.csproj
 
+# Copy source
 COPY ./Difficalcy/ ./Difficalcy/
 COPY ./Difficalcy.Api/ ./Difficalcy.Api/
 COPY ./Difficalcy.Osu/ ./Difficalcy.Osu/
@@ -40,8 +44,13 @@ COPY ./Difficalcy.Mania/ ./Difficalcy.Mania/
 
 RUN mkdir -p /beatmaps && chmod -R 777 /beatmaps
 
+# -----------------------------------------------------------------------------
+
+FROM build-base AS build
 RUN dotnet publish ./Difficalcy.Api/Difficalcy.Api.csproj -o /app/difficalcy --runtime linux-x64 --self-contained true \
     && rm -f /app/difficalcy/*.dbg /app/difficalcy/*.pdb /app/difficalcy/*.Development.json
+
+# -----------------------------------------------------------------------------
 
 FROM base AS publish
 LABEL org.opencontainers.image.description "Lazer powered osu! difficulty calculator API"
@@ -49,8 +58,22 @@ COPY --from=build --chown=app:app /beatmaps /beatmaps
 COPY --from=build /app/difficalcy .
 ENTRYPOINT ["./Difficalcy.Api"]
 
-FROM build AS build-slim
-RUN rm -f /app/difficalcy/*.so /app/difficalcy/*.so.*
+# -----------------------------------------------------------------------------
+
+FROM build-base AS build-slim
+COPY ./tools/StripResources/StripResources.csproj ./tools/StripResources/
+RUN dotnet restore ./tools/StripResources/StripResources.csproj
+COPY ./tools/StripResources/ ./tools/StripResources/
+RUN dotnet build ./tools/StripResources/StripResources.csproj -o /tools && \
+    /tools/StripResources \
+        /root/.nuget/packages/ppy.osu.game.resources/*/lib/netstandard2.1/osu.Game.Resources.dll \
+        /tmp/osu.Game.Resources.dll && \
+    cp /tmp/osu.Game.Resources.dll \
+        /root/.nuget/packages/ppy.osu.game.resources/*/lib/netstandard2.1/osu.Game.Resources.dll && \
+    dotnet publish ./Difficalcy.Api/Difficalcy.Api.csproj -o /app/difficalcy --runtime linux-x64 --self-contained true && \
+    rm -f /app/difficalcy/*.dbg /app/difficalcy/*.pdb /app/difficalcy/*.Development.json /app/difficalcy/*.so /app/difficalcy/*.so.*
+
+# -----------------------------------------------------------------------------
 
 FROM base AS slim
 LABEL org.opencontainers.image.description "Lazer powered osu! difficulty calculator API (slim)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY ./Difficalcy.Mania/ ./Difficalcy.Mania/
 RUN mkdir -p /beatmaps && chmod -R 777 /beatmaps
 
 RUN dotnet publish ./Difficalcy.Api/Difficalcy.Api.csproj -o /app/difficalcy --runtime linux-x64 --self-contained true \
-    && rm -f /app/difficalcy/*.dbg
+    && rm -f /app/difficalcy/*.dbg /app/difficalcy/*.pdb /app/difficalcy/*.Development.json
 
 FROM base AS publish
 LABEL org.opencontainers.image.description "Lazer powered osu! difficulty calculator API"

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN dotnet build ./tools/StripResources/StripResources.csproj -o /tools && \
 
 # -----------------------------------------------------------------------------
 
-FROM base AS slim
+FROM base AS publish-slim
 LABEL org.opencontainers.image.description "Lazer powered osu! difficulty calculator API (slim)"
 COPY --from=build-slim --chown=app:app /beatmaps /beatmaps
 COPY --from=build-slim /app/difficalcy .

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,3 +48,12 @@ LABEL org.opencontainers.image.description "Lazer powered osu! difficulty calcul
 COPY --from=build --chown=app:app /beatmaps /beatmaps
 COPY --from=build /app/difficalcy .
 ENTRYPOINT ["./Difficalcy.Api"]
+
+FROM build AS build-slim
+RUN rm -f /app/difficalcy/*.so /app/difficalcy/*.so.*
+
+FROM base AS slim
+LABEL org.opencontainers.image.description "Lazer powered osu! difficulty calculator API (slim)"
+COPY --from=build-slim --chown=app:app /beatmaps /beatmaps
+COPY --from=build-slim /app/difficalcy .
+ENTRYPOINT ["./Difficalcy.Api"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-noble AS base
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled AS base
 
 LABEL org.opencontainers.image.source https://github.com/Syriiin/difficalcy
 
@@ -16,6 +16,8 @@ USER app
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
+
+COPY ./Directory.Build.props ./
 
 # AOT compilation dependencies
 RUN apt-get update && apt-get install -y clang zlib1g-dev && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMPOSE_E2E = docker compose -f compose.yaml -f compose.override.e2e.yaml
 COMPOSE_E2E_RUN = $(COMPOSE_E2E) run --rm --build e2e-test-runner
 COMPOSE_APP_DEV = docker compose -f compose.yaml -f compose.override.yaml
 COMPOSE_RUN_DOCS = docker compose -f compose.yaml -f compose.override.yaml run --rm --build docs
-COMPOSE_PUBLISH = docker compose -f compose.yaml -f compose.override.publish.yaml
+REPO = ghcr.io/syriiin/difficalcy
 
 help:	## Show this help
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
@@ -47,7 +47,7 @@ fix-formatting:	## Fix code formatting
 
 # TODO: move gh into tooling container (requires env var considerations)
 VERSION =
-release:	## Pushes docker images to ghcr.io and create a github release
+release:	## Pushes docker images to ghcr.io and creates a github release
 ifndef VERSION
 	$(error VERSION is undefined)
 endif
@@ -64,14 +64,20 @@ ifneq "$(shell git diff --name-only master)" ""
 	$(error There are uncommitted changes in the working directory)
 endif
 	echo $$GITHUB_TOKEN | docker login ghcr.io --username $$GITHUB_USERNAME --password-stdin
-	VERSION=$(VERSION) $(COMPOSE_PUBLISH) build
-	VERSION=$(VERSION) $(COMPOSE_PUBLISH) push difficalcy
-	VERSION=latest $(COMPOSE_PUBLISH) build
-	VERSION=latest $(COMPOSE_PUBLISH) push difficalcy
+	docker build . --target publish \
+	    -t $(REPO):$(VERSION) \
+	    -t $(REPO):latest
+	docker build . --target publish-slim \
+	    -t $(REPO):$(VERSION)-slim \
+	    -t $(REPO):latest-slim
+	docker push $(REPO):$(VERSION)
+	docker push $(REPO):latest
+	docker push $(REPO):$(VERSION)-slim
+	docker push $(REPO):latest-slim
 	gh release create "$(VERSION)" --generate-notes
 
 VERSION =
-pre-release:	## Pushes docker image to ghcr.io and create a github prerelease
+pre-release:	## Pushes docker images to ghcr.io and creates a github prerelease
 ifndef VERSION
 	$(error VERSION is undefined)
 endif
@@ -85,6 +91,8 @@ ifneq "$(shell git diff --name-only HEAD)" ""
 	$(error There are uncommitted changes in the working directory)
 endif
 	echo $$GITHUB_TOKEN | docker login ghcr.io --username $$GITHUB_USERNAME --password-stdin
-	VERSION=$(VERSION) $(COMPOSE_PUBLISH) build
-	VERSION=$(VERSION) $(COMPOSE_PUBLISH) push difficalcy
+	docker build . --target publish -t $(REPO):$(VERSION)
+	docker build . --target publish-slim -t $(REPO):$(VERSION)-slim
+	docker push $(REPO):$(VERSION)
+	docker push $(REPO):$(VERSION)-slim
 	gh release create "$(VERSION)" --generate-notes --prerelease --target "$(shell git branch --show-current)"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ bash:	## Opens bash shell in tooling container
 test:	## Runs test suite
 	$(COMPOSE_TOOLING_RUN) dotnet test
 
-test-e2e:	## Runs E2E test suite
+test-e2e:	## Runs E2E test suite (main + slim)
 	$(COMPOSE_E2E_RUN)
 	$(COMPOSE_E2E) down
 

--- a/compose.override.e2e.yaml
+++ b/compose.override.e2e.yaml
@@ -3,8 +3,10 @@ services:
     build: ./e2e
     environment:
       - DIFFICALCY_HOST=difficalcy:80
+      - DIFFICALCY_SLIM_HOST=difficalcy-slim:80
     depends_on:
       - difficalcy
+      - difficalcy-slim
 
   beatmap-server:
     image: caddy:2-alpine
@@ -17,3 +19,14 @@ services:
       - BEATMAP_DOWNLOAD_URL=http://beatmap-server:80/{beatmapId}.osu
     depends_on:
       - beatmap-server
+
+  difficalcy-slim:
+    build:
+      context: .
+      target: slim
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - BEATMAP_DOWNLOAD_URL=http://beatmap-server:80/{beatmapId}.osu
+    depends_on:
+      - beatmap-server
+      - cache

--- a/compose.override.e2e.yaml
+++ b/compose.override.e2e.yaml
@@ -23,7 +23,7 @@ services:
   difficalcy-slim:
     build:
       context: .
-      target: slim
+      target: publish-slim
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - BEATMAP_DOWNLOAD_URL=http://beatmap-server:80/{beatmapId}.osu

--- a/compose.override.publish.yaml
+++ b/compose.override.publish.yaml
@@ -1,3 +1,0 @@
-services:
-  difficalcy:
-    image: ghcr.io/syriiin/difficalcy:${VERSION}

--- a/e2e/test
+++ b/e2e/test
@@ -1,42 +1,48 @@
 #!/bin/bash
 set -euxo pipefail
 
-API="http://$DIFFICALCY_HOST/api/calculators"
+hosts=("$DIFFICALCY_HOST" "${DIFFICALCY_SLIM_HOST:-}")
 
-curl --fail --silent --show-error "$API" | jq
+for host in "${hosts[@]}"; do
+  [ -z "$host" ] && continue
+  echo "=== Testing $host ==="
+  API="http://$host/api/calculators"
 
-curl --fail --silent --show-error "$API/osu/info" | jq
-curl --fail --silent --show-error "$API/osu/calculation?BeatmapId=diffcalc-test-osu" | jq
-curl --fail --silent --show-error "$API/osu/calculation?BeatmapId=diffcalc-test-osu" | jq # Run twice to test caching
-curl --fail --silent --show-error "$API/osu/calculation?BeatmapId=diffcalc-test-osu&Mods=HD,DT" | jq
-curl --fail --silent --show-error -X POST "$API/osu/batch/calculation" \
-  -H "Content-Type: application/json" \
-  -d '[{"BeatmapId": "diffcalc-test-osu"}, {"BeatmapId": "diffcalc-test-osu", "Mods": [{"Acronym": "DT"}]}]' | jq
-curl --fail --silent --show-error "$API/osu/beatmapdetails?BeatmapId=diffcalc-test-osu" | jq
+  curl --fail --silent --show-error "$API" | jq
 
-curl --fail --silent --show-error "$API/taiko/info" | jq
-curl --fail --silent --show-error "$API/taiko/calculation?BeatmapId=diffcalc-test-taiko" | jq
-curl --fail --silent --show-error "$API/taiko/calculation?BeatmapId=diffcalc-test-taiko" | jq # Run twice to test caching
-curl --fail --silent --show-error "$API/taiko/calculation?BeatmapId=diffcalc-test-taiko&Mods=HD,DT" | jq
-curl --fail --silent --show-error -X POST "$API/taiko/batch/calculation" \
-  -H "Content-Type: application/json" \
-  -d '[{"BeatmapId": "diffcalc-test-taiko"}, {"BeatmapId": "diffcalc-test-taiko", "Mods": [{"Acronym": "DT"}]}]' | jq
-curl --fail --silent --show-error "$API/taiko/beatmapdetails?BeatmapId=diffcalc-test-taiko" | jq
+  curl --fail --silent --show-error "$API/osu/info" | jq
+  curl --fail --silent --show-error "$API/osu/calculation?BeatmapId=diffcalc-test-osu" | jq
+  curl --fail --silent --show-error "$API/osu/calculation?BeatmapId=diffcalc-test-osu" | jq
+  curl --fail --silent --show-error "$API/osu/calculation?BeatmapId=diffcalc-test-osu&Mods=HD,DT" | jq
+  curl --fail --silent --show-error -X POST "$API/osu/batch/calculation" \
+    -H "Content-Type: application/json" \
+    -d '[{"BeatmapId": "diffcalc-test-osu"}, {"BeatmapId": "diffcalc-test-osu", "Mods": [{"Acronym": "DT"}]}]' | jq
+  curl --fail --silent --show-error "$API/osu/beatmapdetails?BeatmapId=diffcalc-test-osu" | jq
 
-curl --fail --silent --show-error "$API/catch/info" | jq
-curl --fail --silent --show-error "$API/catch/calculation?BeatmapId=diffcalc-test-catch" | jq
-curl --fail --silent --show-error "$API/catch/calculation?BeatmapId=diffcalc-test-catch" | jq # Run twice to test caching
-curl --fail --silent --show-error "$API/catch/calculation?BeatmapId=diffcalc-test-catch&Mods=HD,DT" | jq
-curl --fail --silent --show-error -X POST "$API/catch/batch/calculation" \
-  -H "Content-Type: application/json" \
-  -d '[{"BeatmapId": "diffcalc-test-catch"}, {"BeatmapId": "diffcalc-test-catch", "Mods": [{"Acronym": "DT"}]}]' | jq
-curl --fail --silent --show-error "$API/catch/beatmapdetails?BeatmapId=diffcalc-test-catch" | jq
+  curl --fail --silent --show-error "$API/taiko/info" | jq
+  curl --fail --silent --show-error "$API/taiko/calculation?BeatmapId=diffcalc-test-taiko" | jq
+  curl --fail --silent --show-error "$API/taiko/calculation?BeatmapId=diffcalc-test-taiko" | jq
+  curl --fail --silent --show-error "$API/taiko/calculation?BeatmapId=diffcalc-test-taiko&Mods=HD,DT" | jq
+  curl --fail --silent --show-error -X POST "$API/taiko/batch/calculation" \
+    -H "Content-Type: application/json" \
+    -d '[{"BeatmapId": "diffcalc-test-taiko"}, {"BeatmapId": "diffcalc-test-taiko", "Mods": [{"Acronym": "DT"}]}]' | jq
+  curl --fail --silent --show-error "$API/taiko/beatmapdetails?BeatmapId=diffcalc-test-taiko" | jq
 
-curl --fail --silent --show-error "$API/mania/info" | jq
-curl --fail --silent --show-error "$API/mania/calculation?BeatmapId=diffcalc-test-mania" | jq
-curl --fail --silent --show-error "$API/mania/calculation?BeatmapId=diffcalc-test-mania" | jq # Run twice to test caching
-curl --fail --silent --show-error "$API/mania/calculation?BeatmapId=diffcalc-test-mania&Mods=HD,DT" | jq
-curl --fail --silent --show-error -X POST "$API/mania/batch/calculation" \
-  -H "Content-Type: application/json" \
-  -d '[{"BeatmapId": "diffcalc-test-mania"}, {"BeatmapId": "diffcalc-test-mania", "Mods": [{"Acronym": "DT"}]}]' | jq
-curl --fail --silent --show-error "$API/mania/beatmapdetails?BeatmapId=diffcalc-test-mania" | jq
+  curl --fail --silent --show-error "$API/catch/info" | jq
+  curl --fail --silent --show-error "$API/catch/calculation?BeatmapId=diffcalc-test-catch" | jq
+  curl --fail --silent --show-error "$API/catch/calculation?BeatmapId=diffcalc-test-catch" | jq
+  curl --fail --silent --show-error "$API/catch/calculation?BeatmapId=diffcalc-test-catch&Mods=HD,DT" | jq
+  curl --fail --silent --show-error -X POST "$API/catch/batch/calculation" \
+    -H "Content-Type: application/json" \
+    -d '[{"BeatmapId": "diffcalc-test-catch"}, {"BeatmapId": "diffcalc-test-catch", "Mods": [{"Acronym": "DT"}]}]' | jq
+  curl --fail --silent --show-error "$API/catch/beatmapdetails?BeatmapId=diffcalc-test-catch" | jq
+
+  curl --fail --silent --show-error "$API/mania/info" | jq
+  curl --fail --silent --show-error "$API/mania/calculation?BeatmapId=diffcalc-test-mania" | jq
+  curl --fail --silent --show-error "$API/mania/calculation?BeatmapId=diffcalc-test-mania" | jq
+  curl --fail --silent --show-error "$API/mania/calculation?BeatmapId=diffcalc-test-mania&Mods=HD,DT" | jq
+  curl --fail --silent --show-error -X POST "$API/mania/batch/calculation" \
+    -H "Content-Type: application/json" \
+    -d '[{"BeatmapId": "diffcalc-test-mania"}, {"BeatmapId": "diffcalc-test-mania", "Mods": [{"Acronym": "DT"}]}]' | jq
+  curl --fail --silent --show-error "$API/mania/beatmapdetails?BeatmapId=diffcalc-test-mania" | jq
+done

--- a/tools/StripResources/Program.cs
+++ b/tools/StripResources/Program.cs
@@ -1,0 +1,40 @@
+// This is a small tool to remove the unnecessary assets from the osu.Game.Resources.dll transitive dep before build time.
+// It's a bit hacky and I don't love it but it saves over 100MB from the final image size, so it's worth it.
+
+using Mono.Cecil;
+
+if (args.Length < 2)
+{
+    Console.Error.WriteLine("Usage: StripResources <input-path> <output-path>");
+    return 1;
+}
+
+string inputPath = args[0];
+string outputPath = args[1];
+
+var parameters = new ReaderParameters { AssemblyResolver = new DefaultAssemblyResolver() };
+using var assembly = AssemblyDefinition.ReadAssembly(inputPath, parameters);
+
+if (assembly.MainModule.Resources.Count == 0)
+{
+    Console.WriteLine("No embedded resources found.");
+    return 0;
+}
+
+int count = assembly.MainModule.Resources.Count;
+long totalSize = 0;
+foreach (var resource in assembly.MainModule.Resources.OfType<EmbeddedResource>())
+{
+    totalSize += resource.GetResourceData().Length;
+}
+
+assembly.MainModule.Resources.Clear();
+assembly.Write(outputPath, new WriterParameters { WriteSymbols = false });
+
+var input = new FileInfo(inputPath);
+var output = new FileInfo(outputPath);
+Console.WriteLine($"Stripped {count} resources ({totalSize / (1024 * 1024):F1} MB)");
+Console.WriteLine($"Input:  {input.Length / (1024 * 1024):F1} MB");
+Console.WriteLine($"Output: {output.Length / (1024 * 1024):F1} MB");
+
+return 0;

--- a/tools/StripResources/StripResources.csproj
+++ b/tools/StripResources/StripResources.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Why?

The raw size of the image is one of the other points I've wanted to optimise for a long time.
With 4x images and each being multiple hundred MB, pushing releases from my home internet was excruciating.

These optimisations drop the size of the images considerably.

For all 4 calcs to run, here's a visual breakdown:
- v0.18.0:
  - ============================== (189.6MB * 4 images = 758.4MB)
  - <sup>this is a long line!</sup>
- v1.0.0-alpha.1:
  - ======== (188.9MB)
  - <sup>this is a much shorter line</sup>
- This PR main image:
  - ====== (144.3MB)
  - <sup>this is pretty good</sup>
- This PR slim image:
  - = (25.5MB)
  - <sup>hot damn!</sup>

## Changes

- Remove unnecessary `.pdb` files
- Switch to chisled base image
- Add `slim` variant which:
    - Remove unnecessary `.so` libs
    - Strips assets (textures, sounds, etc...) from the `osu.Game.Resources.dll` transitive dep assembly
